### PR TITLE
## 2026/04/22 — mobile/balance-04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,67 @@
 # Changelog
 
+## 2026/04/22 — mobile/balance-04
+
+Refines the mobile balance flow by introducing typed money handling, centralized feedback components, and route-aware home refresh behavior. This update improves monetary consistency, simplifies navigation contracts, and makes the home balance experience more reliable after login and route transitions. 
+
+### 1. Monetary handling and parsing
+
+* Added `money2` as a direct dependency and introduced a centralized currency registry in `app_currencies.dart`
+* Defined `BRL` as the default application currency, while keeping `USD`, `EUR`, and `BTC` available for future compatibility
+* Added `ApiParse` helpers to convert API numeric payloads into `BigInt` and `Money`
+* Updated `BalanceResponseDto` and `StatementItemDto` to use `Money` instead of raw integers
+* Centralized conversion from API values to money objects, reducing formatting duplication and improving type safety for balance and statement data
+
+### 2. Home route and navigation behavior
+
+* Added a global `RouteObserver` and registered it in the router
+* Simplified the home route by removing `accountId` extraction from route `extra` and query parameters
+* Adjusted `HomePage` to no longer depend on a route-supplied account id
+* This change makes the home screen less coupled to navigation payload details and more aligned with the authenticated app state
+
+### 3. Home page lifecycle and automatic balance refresh
+
+* Converted `HomePage` state to `RouteAware`
+* Subscribed the page to route lifecycle events through the shared route observer
+* Triggered initialization on `didPush` and `didPopNext`
+* Stopped periodic refresh on `didPop` and `didPushNext`
+* Added a timer in `HomeViewmodel` to reload the balance every 20 seconds after initialization
+* Added explicit `startTimer`, `stopTimer`, and `dispose` methods to manage polling safely
+
+### 4. Balance tile refactor
+
+* Refactored `BalanceTile` to receive typed DTOs instead of preformatted strings
+* Replaced manual currency formatting with `Money.format()`
+* Updated the supporting label to show agency and account information directly from the account DTO
+* Slightly adjusted the card gradient to soften the visual presentation
+
+### 5. Snackbar standardization
+
+* Added reusable `AppSnackbar` with support for `success`, `error`, and `info` variants
+* Centralized snackbar styling, duration, and presentation behavior
+* Replaced direct `ScaffoldMessenger` usage in `LoginPage`
+* Updated pending-feature feedback on the home screen to use the same component
+* This creates a more consistent feedback pattern across the app
+
+### 6. Login flow adjustment
+
+* Updated login result handling to use `AppSnackbar`
+* Moved navigation to `context.goNamed(HomeRoutes.home.name)` after successful command completion handling
+* Changed `_submit()` to trigger the command without duplicating result processing logic afterward
+* Added mounted checks before navigation
+
+### 7. General outcome
+
+* The balance feature now uses a stronger monetary representation end to end
+* The home screen refresh behavior is better synchronized with navigation lifecycle
+* UI feedback is more consistent and reusable
+* The codebase becomes cleaner by removing manual money formatting and reducing route-state complexity
+
+### Conclusion
+
+This commit strengthens the mobile balance experience by combining typed money support, cleaner route handling, periodic balance refresh, and standardized user feedback. The result is a more robust and maintainable implementation for the authenticated home flow.
+
+
 ## 2026/04/22 — mobile/balance-03
 
 Introduces **account balance and statement support in the mobile layer**, including repository abstraction, API integration, caching strategy, and alignment with backend semantics. Also refines documentation to clarify user lifecycle versus account operational status across the system.

--- a/mobile/lib/core/resources/app_currencies.dart
+++ b/mobile/lib/core/resources/app_currencies.dart
@@ -1,0 +1,55 @@
+// mobile/lib/core/resources/money_currency.dart
+
+import 'package:money2/money2.dart';
+
+final appCurrency = AppCurrencies.defaultCurrency;
+
+/// Central registry for supported currencies.
+///
+/// This application currently operates in BRL.
+/// Other currencies are available for future/shared-library compatibility.
+abstract final class AppCurrencies {
+  const AppCurrencies._();
+
+  static final Currency brl = Currency.create(
+    'BRL',
+    2,
+    symbol: 'R\$',
+    pattern: 'S #,##0.00',
+    groupSeparator: '.',
+    decimalSeparator: ',',
+    country: 'BR',
+  );
+
+  static final Currency usd = Currency.create(
+    'USD',
+    2,
+    symbol: '\$',
+    pattern: 'S #,##0.00',
+    groupSeparator: ',',
+    decimalSeparator: '.',
+    country: 'US',
+  );
+
+  static final Currency eur = Currency.create(
+    'EUR',
+    2,
+    symbol: '€',
+    pattern: 'S #,##0.00',
+    groupSeparator: '.',
+    decimalSeparator: ',',
+    country: 'EU',
+  );
+
+  static final Currency btc = Currency.create(
+    'BTC',
+    8,
+    symbol: '₿',
+    pattern: 'S #,##0.00000000',
+    groupSeparator: ',',
+    decimalSeparator: '.',
+    country: 'BTC',
+  );
+
+  static Currency get defaultCurrency => brl;
+}

--- a/mobile/lib/core/routing/route_observer.dart
+++ b/mobile/lib/core/routing/route_observer.dart
@@ -1,0 +1,3 @@
+import 'package:flutter/material.dart';
+
+final routeObserver = RouteObserver<ModalRoute<dynamic>>();

--- a/mobile/lib/core/routing/router.dart
+++ b/mobile/lib/core/routing/router.dart
@@ -3,12 +3,14 @@ import 'package:go_router/go_router.dart';
 
 import '/core/routing/routes.dart';
 import 'extra_codec.dart';
+import 'route_observer.dart';
 import 'routes/auth_routes.dart';
 import 'routes/home_routes.dart';
 
 GoRouter router() => GoRouter(
   initialLocation: AuthRoutes.login.path,
   debugLogDiagnostics: kDebugMode,
+  observers: [routeObserver],
   extraCodec: const ExtraCodec(),
   routes: [
     ...homeRoutes(),

--- a/mobile/lib/core/routing/routes/home_routes.dart
+++ b/mobile/lib/core/routing/routes/home_routes.dart
@@ -9,18 +9,8 @@ List<RouteBase> homeRoutes() => [
   GoRoute(
     path: HomeRoutes.home.path,
     name: HomeRoutes.home.name,
-    builder: (context, state) {
-      final extra = state.extra;
-      final accountId = switch (extra) {
-        String value when value.trim().isNotEmpty => value,
-        Map<String, dynamic> value => value['accountId'] as String?,
-        _ => state.uri.queryParameters['accountId'],
-      };
-
-      return HomePage(
-        viewModel: injector.get<HomeViewmodel>(),
-        accountId: accountId,
-      );
-    },
+    builder: (context, state) => HomePage(
+      viewModel: injector.get<HomeViewmodel>(),
+    ),
   ),
 ];

--- a/mobile/lib/data/services/apis/account/dtos/balance_response_dto.dart
+++ b/mobile/lib/data/services/apis/account/dtos/balance_response_dto.dart
@@ -1,6 +1,10 @@
+import 'package:money2/money2.dart';
+
+import '../../core/api_parse.dart';
+
 class BalanceResponseDto {
   final String accountId;
-  final int balance;
+  final Money balance;
 
   BalanceResponseDto({
     required this.accountId,
@@ -10,7 +14,7 @@ class BalanceResponseDto {
   factory BalanceResponseDto.fromMap(Map<String, dynamic> map) {
     return BalanceResponseDto(
       accountId: map['account_id'] as String,
-      balance: map['balance'] as int,
+      balance: ApiParse.toMoney(map['balance']),
     );
   }
 }

--- a/mobile/lib/data/services/apis/account/dtos/statement_response_dto.dart
+++ b/mobile/lib/data/services/apis/account/dtos/statement_response_dto.dart
@@ -1,8 +1,12 @@
+import 'package:money2/money2.dart';
+
+import '../../core/api_parse.dart';
+
 class StatementItemDto {
   final String transactionId;
   final String type;
-  final int amount;
-  final int balanceAfter;
+  final Money amount;
+  final Money balanceAfter;
   final String? referenceId;
   final String createdAt;
 
@@ -19,8 +23,8 @@ class StatementItemDto {
     return StatementItemDto(
       transactionId: map['transaction_id'] as String,
       type: map['type'] as String,
-      amount: map['amount'] as int,
-      balanceAfter: map['balance_after'] as int,
+      amount: ApiParse.toMoney(map['amount']),
+      balanceAfter: ApiParse.toMoney(map['balance_after']),
       referenceId: map['reference_id'] as String?,
       createdAt: map['created_at'] as String,
     );

--- a/mobile/lib/data/services/apis/core/api_parse.dart
+++ b/mobile/lib/data/services/apis/core/api_parse.dart
@@ -1,0 +1,51 @@
+import 'package:money2/money2.dart';
+
+import '/core/resources/app_currencies.dart';
+
+abstract final class ApiParse {
+  const ApiParse._();
+
+  static BigInt toBigInt(
+    dynamic value, {
+    String fieldName = 'value',
+  }) {
+    if (value is BigInt) return value;
+
+    if (value is int) {
+      return BigInt.from(value);
+    }
+
+    if (value is double) {
+      if (!value.isFinite || value.truncateToDouble() != value) {
+        throw FormatException('Cannot parse BigInt from $fieldName: $value');
+      }
+
+      return BigInt.from(value);
+    }
+
+    if (value is String) {
+      final normalized = value.trim();
+
+      if (normalized.isEmpty) {
+        throw FormatException('Cannot parse BigInt from empty $fieldName');
+      }
+
+      return BigInt.parse(normalized);
+    }
+
+    throw FormatException('Cannot parse BigInt from $fieldName: $value');
+  }
+
+  static Money toMoney(
+    dynamic value, {
+    Currency? currency,
+    String fieldName = 'money value',
+  }) {
+    currency ??= appCurrency;
+
+    final bigIntValue = toBigInt(value, fieldName: fieldName);
+    return Money.fromBigIntWithCurrency(bigIntValue, currency);
+  }
+
+  static BigInt moneyToBigInt(Money value) => value.minorUnits;
+}

--- a/mobile/lib/uis/core/feedback/app_snackbar.dart
+++ b/mobile/lib/uis/core/feedback/app_snackbar.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+enum SnackbarType {
+  success,
+  error,
+  info,
+}
+
+class AppSnackbar {
+  static void show(
+    BuildContext context, {
+    String? title,
+    required String message,
+    SnackbarType type = SnackbarType.info,
+    Duration duration = const Duration(seconds: 3),
+  }) {
+    final backgroundColor = switch (type) {
+      SnackbarType.error => Theme.of(context).colorScheme.error,
+      SnackbarType.success => Theme.of(context).colorScheme.primary,
+      SnackbarType.info => Theme.of(context).colorScheme.secondary,
+    };
+
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          duration: duration,
+          backgroundColor: backgroundColor,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              if (title != null)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 8.0),
+                  child: Text(
+                    title,
+                    style: Theme.of(context).textTheme.titleLarge!.copyWith(
+                      color: Theme.of(context).colorScheme.onPrimary,
+                    ),
+                  ),
+                ),
+              Text(message),
+            ],
+          ),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+  }
+}

--- a/mobile/lib/uis/pages/auth/login/login_page.dart
+++ b/mobile/lib/uis/pages/auth/login/login_page.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import '/core/routing/routes.dart';
 import '/data/services/apis/auth/dtos/login_request_dto.dart';
 import '/uis/core/base/safe_scaffold.dart';
+import '../../../core/feedback/app_snackbar.dart';
 import '../../../core/text_form_field/basic_text_form_field.dart';
 import 'viewmodel/login_viewmodel.dart';
 
@@ -200,27 +201,27 @@ class _LoginPageState extends State<LoginPage> {
 
     if (loginCommand.isFailure) {
       final message = loginCommand.error?.message ?? 'Falha ao autenticar.';
-      ScaffoldMessenger.of(context)
-        ..hideCurrentSnackBar()
-        ..showSnackBar(
-          SnackBar(
-            content: Text(message),
-            behavior: SnackBarBehavior.floating,
-          ),
-        );
+      AppSnackbar.show(
+        context,
+        type: SnackbarType.error,
+        title: 'Erro',
+        message: message,
+      );
+
       return;
     }
 
     if (loginCommand.isSuccess) {
-      ScaffoldMessenger.of(context)
-        ..hideCurrentSnackBar()
-        ..showSnackBar(
-          const SnackBar(
-            content: Text('Login realizado com sucesso.'),
-            behavior: SnackBarBehavior.floating,
-          ),
-        );
+      AppSnackbar.show(
+        context,
+        type: SnackbarType.success,
+        title: 'Sucesso',
+        message: 'Login realizado com sucesso.',
+      );
     }
+
+    if (!mounted) return;
+    context.goNamed(HomeRoutes.home.name);
   }
 
   Future<void> _submit() async {
@@ -229,29 +230,11 @@ class _LoginPageState extends State<LoginPage> {
 
     FocusScope.of(context).unfocus();
 
-    await _viewModel.login.execute(
+    _viewModel.login.execute(
       LoginRequestDto(
         email: _emailController.text.trim(),
         password: _passwordController.text,
       ),
     );
-
-    final result = _viewModel.login.result!;
-    if (result.isFailure) {
-      final message = result.error?.message ?? 'Falha ao autenticar.';
-      if (!mounted) return;
-      ScaffoldMessenger.of(context)
-        ..hideCurrentSnackBar()
-        ..showSnackBar(
-          SnackBar(
-            content: Text(message),
-            behavior: SnackBarBehavior.floating,
-          ),
-        );
-      return;
-    }
-
-    if (!mounted) return;
-    context.goNamed(HomeRoutes.home.name);
   }
 }

--- a/mobile/lib/uis/pages/home/home_page.dart
+++ b/mobile/lib/uis/pages/home/home_page.dart
@@ -1,33 +1,73 @@
 import 'package:flutter/material.dart';
 
+import '/core/routing/route_observer.dart';
 import '../../core/base/safe_scaffold.dart';
+import '../../core/feedback/app_snackbar.dart';
 import 'viewmodel/home_viewmodel.dart';
 import 'widgets/action_tite.dart';
 import 'widgets/balance_tile.dart';
 
 class HomePage extends StatefulWidget {
   final HomeViewmodel viewModel;
-  final String? accountId;
 
   const HomePage({
     super.key,
     required this.viewModel,
-    this.accountId,
   });
 
   @override
   State<HomePage> createState() => _HomePageState();
 }
 
-class _HomePageState extends State<HomePage> {
+class _HomePageState extends State<HomePage> with RouteAware {
   late final HomeViewmodel _viewModel;
+  bool _isRouteObserverSubscribed = false;
 
   @override
   void initState() {
     super.initState();
 
     _viewModel = widget.viewModel;
+  }
 
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    if (_isRouteObserverSubscribed) return;
+
+    final route = ModalRoute.of(context);
+    if (route == null) return;
+
+    routeObserver.subscribe(this, route);
+    _isRouteObserverSubscribed = true;
+  }
+
+  @override
+  void dispose() {
+    routeObserver.unsubscribe(this);
+    _viewModel.dispose();
+
+    super.dispose();
+  }
+
+  @override
+  void didPush() {
+    _viewModel.initialize.execute();
+  }
+
+  @override
+  void didPop() {
+    _viewModel.stopTimer();
+  }
+
+  @override
+  void didPushNext() {
+    _viewModel.stopTimer();
+  }
+
+  @override
+  void didPopNext() {
     _viewModel.initialize.execute();
   }
 
@@ -53,8 +93,8 @@ class _HomePageState extends State<HomePage> {
               ListenableBuilder(
                 listenable: _viewModel.initialize,
                 builder: (context, _) => BalanceTile(
-                  balanceLabel: _balanceLabel(),
-                  supportingLabel: _supportingLabel(),
+                  balance: _viewModel.lastBalance,
+                  account: _viewModel.selectedAccount,
                   isLoading: _viewModel.initialize.isRunning,
                 ),
               ),
@@ -95,25 +135,11 @@ class _HomePageState extends State<HomePage> {
     );
   }
 
-  String _balanceLabel() {
-    final balance = widget.viewModel.lastBalance;
-    if (balance == null) return 'R\$ --';
-
-    final value = (balance.balance / 100)
-        .toStringAsFixed(2)
-        .replaceAll('.', ',');
-    return 'R\$ $value';
-  }
-
   void _showPendingFeature(String featureName) {
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('$featureName sera disponibilizado em breve.')),
+    AppSnackbar.show(
+      context,
+      title: 'Em breve',
+      message: '$featureName será disponibilizado em breve.',
     );
-  }
-
-  String _supportingLabel() {
-    if (_viewModel.initialize.isRunning) return 'Iniciando...';
-
-    return 'Conta: ${_viewModel.selectedAccount!.branch} - ${_viewModel.selectedAccount!.number}';
   }
 }

--- a/mobile/lib/uis/pages/home/viewmodel/home_viewmodel.dart
+++ b/mobile/lib/uis/pages/home/viewmodel/home_viewmodel.dart
@@ -31,6 +31,26 @@ class HomeViewmodel {
     }
 
     await loadBalance();
+
+    startTimer();
     return const Success(unit);
+  }
+
+  Timer? _timer;
+  final Duration _delay = const Duration(seconds: 20);
+
+  void startTimer() {
+    stopTimer();
+
+    _timer = Timer.periodic(_delay, (_) => loadBalance());
+  }
+
+  void stopTimer() {
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  void dispose() {
+    stopTimer();
   }
 }

--- a/mobile/lib/uis/pages/home/widgets/balance_tile.dart
+++ b/mobile/lib/uis/pages/home/widgets/balance_tile.dart
@@ -1,14 +1,17 @@
 import 'package:flutter/material.dart';
 
+import '/data/services/apis/account/dtos/account_summary_response_dto.dart';
+import '/data/services/apis/account/dtos/balance_response_dto.dart';
+
 class BalanceTile extends StatelessWidget {
-  final String balanceLabel;
-  final String supportingLabel;
+  final BalanceResponseDto? balance;
+  final AccountSummaryResponseDto? account;
   final bool isLoading;
 
   const BalanceTile({
     super.key,
-    required this.balanceLabel,
-    required this.supportingLabel,
+    this.balance,
+    required this.account,
     required this.isLoading,
   });
 
@@ -22,7 +25,7 @@ class BalanceTile extends StatelessWidget {
         gradient: LinearGradient(
           colors: [
             colorScheme.primary,
-            colorScheme.primaryContainer,
+            colorScheme.primary.withValues(alpha: .6),
           ],
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
@@ -40,7 +43,7 @@ class BalanceTile extends StatelessWidget {
           ),
           const SizedBox(height: 12),
           Text(
-            balanceLabel,
+            _balanceLabel(),
             style: Theme.of(context).textTheme.headlineMedium?.copyWith(
               color: colorScheme.onPrimary,
               fontWeight: FontWeight.w700,
@@ -49,7 +52,7 @@ class BalanceTile extends StatelessWidget {
           const SizedBox(height: 12),
           if (!isLoading) ...[
             Text(
-              supportingLabel,
+              _supportingLabel(),
               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                 color: colorScheme.onPrimary.withValues(alpha: 0.86),
               ),
@@ -66,5 +69,17 @@ class BalanceTile extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  String _balanceLabel() {
+    if (balance == null) return 'R\$ ---';
+
+    return balance!.balance.format();
+  }
+
+  String _supportingLabel() {
+    if (isLoading || account == null) return 'Iniciando...';
+
+    return 'Agência: ${account!.branch} - Conta: ${account!.number}';
   }
 }

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -81,6 +81,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  decimal:
+    dependency: transitive
+    description:
+      name: decimal
+      sha256: fc706a5618b81e5b367b01dd62621def37abc096f2b46a9bd9068b64c1fa36d0
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.4"
   dio:
     dependency: "direct main"
     description:
@@ -121,6 +129,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  fixed:
+    dependency: transitive
+    description:
+      name: fixed
+      sha256: "233bf345eefebd10ef382054060de4d60eab452455391b03ba8e2ff3fe45777f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.1"
   fixnum:
     dependency: transitive
     description:
@@ -344,6 +360,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  money2:
+    dependency: "direct main"
+    description:
+      name: money2
+      sha256: "695f317508beae72c392d0d62fd4c1f9ac1127e25117aaf2e75e20953139ffce"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.0"
   native_toolchain_c:
     dependency: transitive
     description:
@@ -448,6 +472,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  rational:
+    dependency: transitive
+    description:
+      name: rational
+      sha256: cb808fb6f1a839e6fc5f7d8cb3b0a10e1db48b3be102de73938c627f0b636336
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.3"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   flutter_secure_storage: ^10.0.0
   uuid: ^4.5.3
   google_fonts: ^8.0.2
+  money2: ^6.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Refines the mobile balance flow by introducing typed money handling, centralized feedback components, and route-aware home refresh behavior. This update improves monetary consistency, simplifies navigation contracts, and makes the home balance experience more reliable after login and route transitions.

### 1. Monetary handling and parsing

* Added `money2` as a direct dependency and introduced a centralized currency registry in `app_currencies.dart`
* Defined `BRL` as the default application currency, while keeping `USD`, `EUR`, and `BTC` available for future compatibility
* Added `ApiParse` helpers to convert API numeric payloads into `BigInt` and `Money`
* Updated `BalanceResponseDto` and `StatementItemDto` to use `Money` instead of raw integers
* Centralized conversion from API values to money objects, reducing formatting duplication and improving type safety for balance and statement data

### 2. Home route and navigation behavior

* Added a global `RouteObserver` and registered it in the router
* Simplified the home route by removing `accountId` extraction from route `extra` and query parameters
* Adjusted `HomePage` to no longer depend on a route-supplied account id
* This change makes the home screen less coupled to navigation payload details and more aligned with the authenticated app state

### 3. Home page lifecycle and automatic balance refresh

* Converted `HomePage` state to `RouteAware`
* Subscribed the page to route lifecycle events through the shared route observer
* Triggered initialization on `didPush` and `didPopNext`
* Stopped periodic refresh on `didPop` and `didPushNext`
* Added a timer in `HomeViewmodel` to reload the balance every 20 seconds after initialization
* Added explicit `startTimer`, `stopTimer`, and `dispose` methods to manage polling safely

### 4. Balance tile refactor

* Refactored `BalanceTile` to receive typed DTOs instead of preformatted strings
* Replaced manual currency formatting with `Money.format()`
* Updated the supporting label to show agency and account information directly from the account DTO
* Slightly adjusted the card gradient to soften the visual presentation

### 5. Snackbar standardization

* Added reusable `AppSnackbar` with support for `success`, `error`, and `info` variants
* Centralized snackbar styling, duration, and presentation behavior
* Replaced direct `ScaffoldMessenger` usage in `LoginPage`
* Updated pending-feature feedback on the home screen to use the same component
* This creates a more consistent feedback pattern across the app

### 6. Login flow adjustment

* Updated login result handling to use `AppSnackbar`
* Moved navigation to `context.goNamed(HomeRoutes.home.name)` after successful command completion handling
* Changed `_submit()` to trigger the command without duplicating result processing logic afterward
* Added mounted checks before navigation

### 7. General outcome

* The balance feature now uses a stronger monetary representation end to end
* The home screen refresh behavior is better synchronized with navigation lifecycle
* UI feedback is more consistent and reusable
* The codebase becomes cleaner by removing manual money formatting and reducing route-state complexity

### Conclusion

This commit strengthens the mobile balance experience by combining typed money support, cleaner route handling, periodic balance refresh, and standardized user feedback. The result is a more robust and maintainable implementation for the authenticated home flow.