### PR TITLE
## 2026/05/11 - mobile/short-login-01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,117 @@
 # Changelog
 
+## 2026/05/11 - mobile/short-login-01
+
+Refactor authentication profile loading flow and introduce support structures for short login persistence on the mobile application.
+
+### Authentication and profile integration
+
+This commit restructures the mobile authentication profile retrieval flow to align the client with the current API contract by separating identity and customer profile responsibilities between `/auth/me` and `/customers/me`.
+
+#### Updated `AuthApi.getProfile()`
+
+* Replaced the old `profile/me` request with:
+
+  * `GET /customers/me`
+  * `GET /auth/me`
+* Added explicit parsing and validation for both response envelopes.
+* Merged both endpoint responses into a unified `UserProfile` model through a dedicated factory constructor.
+* Improved failure propagation and parsing isolation for each endpoint.
+* Preserved compatibility with the API response envelope strategy already established in the backend documentation.
+
+### New DTOs for authentication/profile separation
+
+Added dedicated transport DTOs:
+
+#### `AuthMeResponseDto`
+
+Represents authenticated identity/session information:
+
+* user id
+* role
+* email
+* customer id
+
+#### `CustomerMeResponseDto`
+
+Represents customer profile information:
+
+* customer id
+* name
+* cpf
+* email
+* createdAt
+
+This separation better reflects the backend architecture and authorization model currently implemented in the API.
+
+### User profile model improvements
+
+Extended `UserProfile` with:
+
+```dart
+UserProfile.fromMe(...)
+```
+
+This constructor consolidates:
+
+* authenticated user context
+* customer profile data
+
+into a single application-facing representation.
+
+The new approach reduces coupling between API transport contracts and UI/domain consumption.
+
+### Short login persistence support
+
+Added new secure/local storage keys:
+
+```dart
+lastLoginName
+lastLoginIdentifier
+```
+
+These keys prepare the application for:
+
+* cached login identity
+* short login flows
+* reduced friction during authentication
+* future biometric or transactional authentication extensions
+
+This is an important step toward a banking-style login experience where:
+
+* the user identity remains cached locally
+* only the credential confirmation step is required on subsequent accesses
+
+### Import and path normalization
+
+Adjusted several imports to:
+
+* use absolute project-based imports
+* reduce relative path traversal
+* improve consistency across the mobile module
+
+This includes updates in:
+
+* `details_page.dart`
+* authentication DTO/model integration files
+
+### Architectural alignment
+
+The changes reinforce the separation already defined in the backend architecture:
+
+* identity/session context from `/auth/me`
+* customer/business profile from `/customers/me`
+
+This keeps the mobile client aligned with:
+
+* JWT ownership rules
+* customer-bound authorization
+* modular backend boundaries
+* future Zero Trust evolution paths
+
+The result is a cleaner authentication/profile pipeline with improved transport separation, reduced coupling, and a stronger foundation for future secure login and contextual authentication features.
+
+
 ## 2026/05/11 - mobile/internal-transfer-11
 
 Refactor the internal transfer flow and introduce a complete transfer receipt/details experience in the Flutter mobile client.

--- a/mobile/lib/core/resources/storage_keys.dart
+++ b/mobile/lib/core/resources/storage_keys.dart
@@ -1,4 +1,7 @@
 final class StorageKeys {
   static const accessToken = 'auth_token';
   static const refreshToken = 'refresh_token';
+
+  static const lastLoginName = 'last_login_name';
+  static const lastLoginIdentifier = 'last_login_identifier';
 }

--- a/mobile/lib/data/services/apis/auth/auth_api.dart
+++ b/mobile/lib/data/services/apis/auth/auth_api.dart
@@ -6,6 +6,8 @@ import '/data/services/apis/auth/dtos/login_request_dto.dart';
 import '/domain/common/auth/models/auth_user.dart';
 import '/domain/common/auth/models/user_profile.dart';
 import '../core/api_envelope.dart';
+import 'dtos/auth_me_response_dto.dart';
+import 'dtos/customer_me_response_dto.dart';
 import 'dtos/register_request_dto.dart';
 import 'dtos/register_response_dto.dart';
 
@@ -131,30 +133,38 @@ class AuthApi {
 
   // Remove this to a profile API service.
   AsyncResult<UserProfile> getProfile() async {
-    final response = await _client.get(
+    final respCustomer = await _client.get(
       RestClientRequest(
-        path: 'profile/me',
+        path: '/customers/me',
       ),
     );
 
-    if (response.isFailure) return Result.failure(response.error!);
+    if (respCustomer.isFailure) return Result.failure(respCustomer.error!);
+
+    final respMe = await _client.get(
+      RestClientRequest(
+        path: '/auth/me',
+      ),
+    );
+
+    if (respMe.isFailure) return Result.failure(respMe.error!);
 
     try {
-      final envelope = ApiEnvelope<UserProfile>.fromMap(
-        response.value as Map<String, dynamic>,
-        UserProfile.fromMap,
+      final envCustomer = ApiEnvelope<CustomerMeResponseDto>.fromMap(
+        respCustomer.value as Map<String, dynamic>,
+        CustomerMeResponseDto.fromMap,
       );
 
-      if (envelope.error != null) {
+      if (envCustomer.error != null) {
         return Failure(
           AppError(
             code: AppErrorCode.httpError,
-            message: envelope.error!.message,
+            message: envCustomer.error!.message,
           ),
         );
       }
 
-      if (envelope.data == null) {
+      if (envCustomer.data == null) {
         return Failure(
           AppError(
             code: AppErrorCode.httpError,
@@ -163,7 +173,29 @@ class AuthApi {
         );
       }
 
-      return Success(envelope.data!);
+      final envUserMe = ApiEnvelope<AuthMeResponseDto>.fromMap(
+        respMe.value as Map<String, dynamic>,
+        AuthMeResponseDto.fromMap,
+      );
+
+      if (envUserMe.error != null) {
+        return Failure(
+          AppError(
+            code: AppErrorCode.httpError,
+            message: envUserMe.error!.message,
+          ),
+        );
+      }
+
+      final authMe = envUserMe.data!;
+      final customer = envCustomer.data!;
+
+      final userProfile = UserProfile.fromMe(
+        userMe: authMe,
+        customer: customer,
+      );
+
+      return Success(userProfile);
     } catch (err, stack) {
       _log.error('Error parsing response: $err', error: err, stack: stack);
       return Failure(

--- a/mobile/lib/data/services/apis/auth/dtos/auth_me_response_dto.dart
+++ b/mobile/lib/data/services/apis/auth/dtos/auth_me_response_dto.dart
@@ -1,0 +1,24 @@
+import '/domain/common/user/enums/user_role.dart';
+
+class AuthMeResponseDto {
+  final String id;
+  final UserRole role;
+  final String email;
+  final String customerId;
+
+  AuthMeResponseDto({
+    required this.id,
+    required this.role,
+    required this.email,
+    required this.customerId,
+  });
+
+  factory AuthMeResponseDto.fromMap(Map<String, dynamic> map) {
+    return AuthMeResponseDto(
+      id: map['id'] as String,
+      role: UserRole.byName(map['role'] as String),
+      email: map['email'] as String,
+      customerId: map['customerId'] as String,
+    );
+  }
+}

--- a/mobile/lib/data/services/apis/auth/dtos/customer_me_response_dto.dart
+++ b/mobile/lib/data/services/apis/auth/dtos/customer_me_response_dto.dart
@@ -1,0 +1,28 @@
+import '/core/extensions/datetime_extension.dart';
+
+class CustomerMeResponseDto {
+  final String id;
+  final String name;
+  final String cpf;
+  final String email;
+  final DateTime createdAt;
+
+  CustomerMeResponseDto({
+    required this.id,
+    required this.name,
+    required this.cpf,
+    required this.email,
+    required this.createdAt,
+  });
+
+  factory CustomerMeResponseDto.fromMap(Map<String, dynamic> map) {
+    return CustomerMeResponseDto(
+      id: map['id'] as String,
+      name: map['name'] as String,
+      cpf: map['cpf'] as String,
+      email: map['email'] as String,
+      createdAt:
+          DateTimeExtensions.parseOrNull(map['createdAt']) ?? DateTime.now(),
+    );
+  }
+}

--- a/mobile/lib/domain/common/auth/models/user_profile.dart
+++ b/mobile/lib/domain/common/auth/models/user_profile.dart
@@ -1,4 +1,6 @@
 import '/core/extensions/datetime_extension.dart';
+import '/data/services/apis/auth/dtos/auth_me_response_dto.dart';
+import '/data/services/apis/auth/dtos/customer_me_response_dto.dart';
 import '/domain/common/user/enums/user_role.dart';
 
 class UserProfile {
@@ -29,6 +31,21 @@ class UserProfile {
       customerId: map['customer_id'] as String,
       createdAt: DateTimeExtensions.parseOrNull(map['created_at'] as String)!,
       updatedAt: DateTimeExtensions.parseOrNull(map['updated_at'] as String)!,
+    );
+  }
+
+  factory UserProfile.fromMe({
+    required AuthMeResponseDto userMe,
+    required CustomerMeResponseDto customer,
+  }) {
+    return UserProfile(
+      userId: userMe.id,
+      name: customer.name,
+      email: userMe.email,
+      role: userMe.role,
+      customerId: userMe.customerId,
+      createdAt: customer.createdAt,
+      updatedAt: DateTime.now(),
     );
   }
 }

--- a/mobile/lib/uis/pages/shared/details/details_page.dart
+++ b/mobile/lib/uis/pages/shared/details/details_page.dart
@@ -9,13 +9,13 @@ import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
 
 import '/core/extensions/datetime_extension.dart';
+import '/core/routing/routes.dart';
 import '/data/services/apis/receipt/dtos/transfer_receipt_response_dto.dart';
 import '/domain/common/receipt/enums/transfer_receipt_status.dart';
 import '/uis/core/base/safe_scaffold.dart';
-import '../../../../core/routing/routes.dart';
-import '../../../core/buttons/big_button.dart';
-import '../../../core/buttons/big_text_button.dart';
-import '../../../core/messages/app_snackbar.dart';
+import '/uis/core/buttons/big_button.dart';
+import '/uis/core/buttons/big_text_button.dart';
+import '/uis/core/messages/app_snackbar.dart';
 import 'viewmodel/details_viewmodel.dart';
 import 'widgets/detail_line.dart';
 


### PR DESCRIPTION
Refactor authentication profile loading flow and introduce support structures for short login persistence on the mobile application.

### Authentication and profile integration

This commit restructures the mobile authentication profile retrieval flow to align the client with the current API contract by separating identity and customer profile responsibilities between `/auth/me` and `/customers/me`.

#### Updated `AuthApi.getProfile()`

* Replaced the old `profile/me` request with:

  * `GET /customers/me`
  * `GET /auth/me`
* Added explicit parsing and validation for both response envelopes.
* Merged both endpoint responses into a unified `UserProfile` model through a dedicated factory constructor.
* Improved failure propagation and parsing isolation for each endpoint.
* Preserved compatibility with the API response envelope strategy already established in the backend documentation.

### New DTOs for authentication/profile separation

Added dedicated transport DTOs:

#### `AuthMeResponseDto`

Represents authenticated identity/session information:

* user id
* role
* email
* customer id

#### `CustomerMeResponseDto`

Represents customer profile information:

* customer id
* name
* cpf
* email
* createdAt

This separation better reflects the backend architecture and authorization model currently implemented in the API.

### User profile model improvements

Extended `UserProfile` with:

```dart
UserProfile.fromMe(...)
```

This constructor consolidates:

* authenticated user context
* customer profile data

into a single application-facing representation.

The new approach reduces coupling between API transport contracts and UI/domain consumption.

### Short login persistence support

Added new secure/local storage keys:

```dart
lastLoginName
lastLoginIdentifier
```

These keys prepare the application for:

* cached login identity
* short login flows
* reduced friction during authentication
* future biometric or transactional authentication extensions

This is an important step toward a banking-style login experience where:

* the user identity remains cached locally
* only the credential confirmation step is required on subsequent accesses

### Import and path normalization

Adjusted several imports to:

* use absolute project-based imports
* reduce relative path traversal
* improve consistency across the mobile module

This includes updates in:

* `details_page.dart`
* authentication DTO/model integration files

### Architectural alignment

The changes reinforce the separation already defined in the backend architecture:

* identity/session context from `/auth/me`
* customer/business profile from `/customers/me`

This keeps the mobile client aligned with:

* JWT ownership rules
* customer-bound authorization
* modular backend boundaries
* future Zero Trust evolution paths

The result is a cleaner authentication/profile pipeline with improved transport separation, reduced coupling, and a stronger foundation for future secure login and contextual authentication features.