### PR TITLE
## 2026/06/10 - api/zta-mvp-transactional-password-16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,92 @@
 # Changelog
 
-Segue o texto do commit:
+## 2026/06/10 - api/zta-mvp-transactional-password-16
+
+This update completes the transactional password step-up flow by strengthening token lifecycle management, hardening request validation, expanding integration coverage, and consolidating the public API contract around operation-based authorization.
+
+1. `step-up token lifecycle`
+
+   * Added migration `000012_step_up_tokens_cleanup`.
+   * Introduced `cleanup_step_up_tokens()` database function.
+   * Added dedicated indexes for active and consumed token cleanup paths.
+   * Configured a daily `pg_cron` job to remove expired operational records.
+   * Implemented a 24-hour retention window for both expired and consumed tokens.
+   * Preserved short-term auditability while preventing indefinite growth of the `step_up_tokens` table.
+
+2. `step-up authorization flow`
+
+   * Changed token generation flow to sign the JWT before persisting the authorization record.
+   * Prevented persistence of unusable step-up authorizations when token signing fails.
+   * Added explicit tests covering signing failures and persistence failures.
+   * Preserved the guarantee that only valid signed tokens can be stored for future enforcement.
+
+3. `strict JSON request validation`
+
+   * Introduced shared `DecodeJSON()` helper under `internal/shared/http`.
+
+   * Centralized strict request decoding logic.
+
+   * Continued rejecting unknown fields.
+
+   * Added rejection of multiple JSON values in a single request body.
+
+   * Prevented payloads such as:
+
+     ```json
+     {"field":"value"}{"extra":"payload"}
+     ```
+
+   * Applied the shared decoder to:
+
+     * transaction password creation
+     * step-up authorization
+     * internal transfer requests
+
+4. `internal transfer protection`
+
+   * Added integration coverage for the complete protected transfer flow.
+   * Validated transaction password creation.
+   * Validated step-up authorization issuance.
+   * Validated protected transfer execution using `X-Step-Up-Token`.
+   * Verified single-use token consumption behavior.
+   * Verified rejection of reused step-up tokens.
+   * Verified compatibility with transfer idempotency semantics.
+
+5. `public step-up contract`
+
+   * Standardized authorization requests around:
+
+     * HTTP method
+     * HTTP path
+   * Removed public exposure of internal endpoint policy identifiers.
+   * Documented canonical uppercase method usage.
+   * Added normalization rules for method handling.
+   * Clarified that paths are trimmed but never rewritten or normalized by the API.
+   * Reinforced the separation between public operation contracts and internal policy resolution.
+
+6. `API documentation`
+
+   * Documented step-up token retention and cleanup behavior.
+   * Added `step_up_tokens` table to database documentation.
+   * Updated implementation documentation to include operational retention rules.
+   * Clarified authorization error behavior for protected transfers.
+   * Documented that internal transfers return `STEP_UP_TOKEN_REQUIRED` when the authorization header is missing.
+   * Expanded step-up implementation notes to reflect the final operational model.
+
+7. `security delivery layer`
+
+   * Added handler documentation and constructor documentation.
+   * Improved endpoint self-documentation around transaction password creation and step-up authorization responsibilities.
+   * Increased maintainability of the security module entry points.
+
+8. `mobile and tooling`
+
+   * Added `AppEnv.isDev` and `AppEnv.isStaging`.
+   * Enabled contact verification debug token handling in staging environments.
+   * Updated the Bruno environment to target the public staging endpoint.
+
+This commit finalizes the operational foundations of transactional-password-based step-up authentication. Authorization tokens are now single-use, retention-managed, strictly validated at the HTTP boundary, and fully covered by end-to-end transfer integration tests, providing a safer and more predictable security model for sensitive banking operations.
+
 
 ## 2026/06/09 - banklab/docker-environment-isolation-02
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Docker, migrations e inicialização da API no host.
 As durações de token podem ser configuradas com `JWT_ACCESS_TOKEN_DURATION` e
 `JWT_REFRESH_TOKEN_DURATION`; quando omitidas, a API usa `15m` e `168h`.
 
-O banco local é criado a partir de uma imagem customizada baseada em PostgreSQL 17 com `pg_cron`. A extensão é usada para rotinas agendadas de manutenção do banco, como a limpeza diária de verificações temporárias de contato.
+O banco local é criado a partir de uma imagem customizada baseada em PostgreSQL 17 com `pg_cron`. A extensão é usada para rotinas agendadas de manutenção do banco, como a limpeza diária de verificações temporárias de contato e de tokens de step-up após a janela operacional de retenção.
 
 URL padrão da API:
 

--- a/api/cmd/api/routes_test.go
+++ b/api/cmd/api/routes_test.go
@@ -157,7 +157,7 @@ func TestAPIRouter_StepUpAuthorizeRouteRequiresAuth(t *testing.T) {
 	req := httptest.NewRequest(
 		http.MethodPost,
 		"/security/step-up/authorize",
-		strings.NewReader(`{"endpoint_key":"internal_transfer.create","transaction_password":"123456"}`),
+		strings.NewReader(`{"method":"POST","path":"/accounts/internal-transfers","transaction_password":"123456"}`),
 	)
 	rec := httptest.NewRecorder()
 

--- a/api/docs/06-implementation.md
+++ b/api/docs/06-implementation.md
@@ -480,11 +480,15 @@ Applied migration files include:
 - ledger persistence centered on `transactions`
 - transfer pair integrity indexes (`reference_id`, `reference_id+type` unique per transfer leg)
 - contact verification cleanup using `pg_cron`
+- step-up token cleanup using `pg_cron`, with 24-hour retention after
+  expiration or consumption
 
 Important implementation detail:
 - account operations persist ledger entries exclusively in `transactions`.
 - idempotent transfer replay is reconstructed from ledger rows (`transfer_out` + paired `transfer_in`) using `reference_id`.
 - contact verification requests are unique by `(target, channel)`; requesting a new code for the same contact replaces the previous pending attempt.
+- expired and consumed step-up token records are cleaned daily after their
+  24-hour operational retention window.
 
 ## 9. Consistency and Concurrency Strategy (Implemented)
 

--- a/api/docs/07-api-rest.md
+++ b/api/docs/07-api-rest.md
@@ -694,6 +694,12 @@ The client must send only the public HTTP operation (`method` + `path`).
 Internal policy keys (for example `internal_transfer.create`) are resolved by
 the backend and are not part of the public request contract.
 
+The canonical client representation uses an uppercase HTTP method, such as
+`POST`. For input tolerance, the API trims surrounding whitespace and
+normalizes `method` to uppercase before resolving the operation allowlist.
+The API only trims surrounding whitespace from `path`; it does not normalize
+or rewrite the path itself.
+
 Request body:
 
 ```json
@@ -1035,7 +1041,6 @@ Possible errors:
 - 400 SAME_ACCOUNT_TRANSFER: source and destination are equal
 - 403 FORBIDDEN: authenticated user cannot operate the source account
 - 403 STEP_UP_ENDPOINT_MISMATCH: step-up token operation does not match
-- 403 TRANSACTION_PASSWORD_REQUIRED: endpoint requires step-up authorization
 - 404 ACCOUNT_NOT_FOUND: source or destination account not found
 - 422 INSUFFICIENT_FUNDS: source account has insufficient funds
 - 422 ACCOUNT_INACTIVE: one account is inactive
@@ -1304,7 +1309,9 @@ validation attempt receives an incorrect PIN.
 password is temporarily locked after repeated invalid attempts.
 
 `TRANSACTION_PASSWORD_REQUIRED` (HTTP 403) is reserved for challenge/policy
-flows that require step-up before a sensitive operation can proceed.
+flows that require step-up before a sensitive operation can proceed. It is not
+returned by `POST /accounts/internal-transfers`; that endpoint returns
+`STEP_UP_TOKEN_REQUIRED` when `X-Step-Up-Token` is missing.
 
 `STEP_UP_TOKEN_REQUIRED` (HTTP 401) is returned by protected endpoints when
 header `X-Step-Up-Token` is missing.

--- a/api/docs/09-database.md
+++ b/api/docs/09-database.md
@@ -182,7 +182,33 @@ Fields:
 
 ---
 
-## 4.4 accounts
+## 4.5 step_up_tokens
+
+Represents short-lived, single-use step-up authorizations.
+
+Fields:
+
+* `id` (UUID, PK)
+* `jti` (unique JWT identifier)
+* `user_id` (FK → users)
+* `endpoint_key`
+* `status` (`active` or `consumed`)
+* `expires_at`
+* `consumed_at`
+* `created_at`
+
+Notes:
+
+* active tokens are rejected after `expires_at`
+* successful enforcement atomically changes the token to `consumed`
+* active tokens expired for more than 24 hours are removed
+* consumed tokens are retained for 24 hours after `consumed_at`
+* cleanup is performed daily at 03:15 by `pg_cron` through
+  `cleanup_step_up_tokens()`
+
+---
+
+## 4.6 accounts
 
 Represents a financial account.
 
@@ -204,7 +230,7 @@ Notes:
 
 ---
 
-## 4.5 transactions
+## 4.7 transactions
 
 Represents the **financial ledger**.
 
@@ -224,7 +250,7 @@ Fields:
 
 ---
 
-## 4.6 contact_verifications
+## 4.8 contact_verifications
 
 Represents temporary onboarding verifications for e-mail and phone.
 

--- a/api/docs/implementations/03-zta-step-up-transaction-password.md
+++ b/api/docs/implementations/03-zta-step-up-transaction-password.md
@@ -178,6 +178,11 @@ O contrato publico de autorizacao nao recebe `endpoint_key`. Essa chave pode
 continuar existindo apenas internamente no backend e no JWT assinado para
 enforcement.
 
+O cliente deve enviar `method` na forma canonica em maiusculas, como `POST`.
+Como tolerancia de entrada, a API remove espacos externos e normaliza `method`
+para maiusculas antes de consultar a whitelist. Para `path`, a API remove apenas
+espacos externos; nao altera nem reescreve o caminho informado.
+
 Resposta definida, seguindo o envelope de resposta da API:
 
 ```json
@@ -342,6 +347,11 @@ step_up_tokens
 
 Mesmo que o token seja JWT, o backend precisa rastrear um identificador para
 garantir uso único.
+
+Tokens `active` expirados são mantidos por 24 horas após `expires_at`. Tokens
+`consumed` são mantidos por 24 horas após `consumed_at`. Depois desse período,
+`cleanup_step_up_tokens()` remove os registros diariamente por meio de
+`pg_cron`, às 03:15 no timezone configurado para o banco.
 
 ## Resultado esperado
 

--- a/api/internal/account/transaction/delivery/handler.go
+++ b/api/internal/account/transaction/delivery/handler.go
@@ -208,9 +208,7 @@ func (h *Handler) Transfer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req TransferRequest
-	decoder := json.NewDecoder(r.Body)
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&req); err != nil {
+	if err := sharedhttp.DecodeJSON(r.Body, &req); err != nil {
 		sharedhttp.WriteError(w, sharederrors.MapError(sharederrors.ErrInvalidRequest))
 		return
 	}

--- a/api/internal/account/transaction/delivery/handler_test.go
+++ b/api/internal/account/transaction/delivery/handler_test.go
@@ -590,6 +590,51 @@ func TestHandler_Transfer_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestHandler_Transfer_RejectsSecondJSONValue(t *testing.T) {
+	customerID := uuid.New()
+	fromAccountID := uuid.New()
+	toAccountID := uuid.New()
+	transferUC := &transferUseCaseMock{}
+	enforceUC := &enforceStepUpUseCaseMock{}
+	h := &Handler{transfer: transferUC, enforceStepUp: enforceUC}
+
+	body := `{"from_account_id":"` + fromAccountID.String() +
+		`","to_account_id":"` + toAccountID.String() +
+		`","amount":100,"idempotency_key":"second-json-value"}{}`
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/accounts/internal-transfers",
+		strings.NewReader(body),
+	)
+	req = testAuthenticatedRequest(req, customerID)
+	req = withStepUpToken(req, "signed-step-up-token")
+	rec := httptest.NewRecorder()
+
+	h.Transfer(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rec.Code)
+	}
+
+	var got struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("failed to decode response body: %v", err)
+	}
+	if got.Error.Code != "INVALID_REQUEST" {
+		t.Fatalf("expected error code %q, got %q", "INVALID_REQUEST", got.Error.Code)
+	}
+	if enforceUC.executeCalls != 0 {
+		t.Fatalf("expected enforcement not to be called, got %d calls", enforceUC.executeCalls)
+	}
+	if transferUC.executeCalls != 0 {
+		t.Fatalf("expected transfer not to be called, got %d calls", transferUC.executeCalls)
+	}
+}
+
 func TestHandler_Transfer_InvalidAmount(t *testing.T) {
 	customerID := uuid.New()
 	fromAccountID := uuid.New()

--- a/api/internal/account/transaction/delivery/step_up_transfer_integration_test.go
+++ b/api/internal/account/transaction/delivery/step_up_transfer_integration_test.go
@@ -1,0 +1,513 @@
+package delivery
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	transactionapplication "github.com/seu-usuario/bank-api/internal/account/transaction/application"
+	transactioninfrastructure "github.com/seu-usuario/bank-api/internal/account/transaction/infrastructure"
+	authdomain "github.com/seu-usuario/bank-api/internal/auth/domain"
+	authinfrastructure "github.com/seu-usuario/bank-api/internal/auth/infrastructure"
+	securityapplication "github.com/seu-usuario/bank-api/internal/security/application"
+	securitydelivery "github.com/seu-usuario/bank-api/internal/security/delivery"
+	securitydomain "github.com/seu-usuario/bank-api/internal/security/domain"
+	securityinfrastructure "github.com/seu-usuario/bank-api/internal/security/infrastructure"
+	sharedauthctx "github.com/seu-usuario/bank-api/internal/shared/authctx"
+	"golang.org/x/crypto/bcrypt"
+)
+
+func TestIntegration_StepUpProtectedInternalTransfer(t *testing.T) {
+	ctx := context.Background()
+	pool := newTestPool(t, ctx)
+	defer pool.Close()
+
+	ensureStepUpTransferTestSchema(t, ctx, pool)
+
+	userID := uuid.New()
+	sourceCustomerID := uuid.New()
+	destinationCustomerID := uuid.New()
+	sourceAccountID := uuid.New()
+	destinationAccountID := uuid.New()
+
+	seedTransferTestData(
+		t,
+		ctx,
+		pool,
+		sourceCustomerID,
+		destinationCustomerID,
+		sourceAccountID,
+		destinationAccountID,
+		"0001",
+		uniqueAccountNumber("31"),
+		"0001",
+		uniqueAccountNumber("32"),
+		10000,
+		5000,
+	)
+	seedStepUpTransferUser(t, ctx, pool, userID, sourceCustomerID)
+	defer cleanupStepUpTransferTestData(
+		t,
+		ctx,
+		pool,
+		userID,
+		sourceCustomerID,
+		destinationCustomerID,
+		sourceAccountID,
+		destinationAccountID,
+	)
+
+	const (
+		transactionPIN = "123456"
+		idempotencyKey = "step-up-transfer-integration-key"
+		jwtSecret      = "step-up-transfer-integration-secret"
+		pepper         = "step-up-transfer-integration-pepper-32-bytes"
+	)
+
+	userRepo := authinfrastructure.NewPostgresUserRepository(pool)
+	passwordRepo := securityinfrastructure.NewPostgresTransactionPasswordRepository(pool)
+	tokenRepo := securityinfrastructure.NewPostgresStepUpTokenRepository(pool)
+	passwordHasher := securityinfrastructure.NewBcryptTransactionPasswordHasher(
+		bcrypt.MinCost,
+		pepper,
+	)
+	tokenSigner := securityinfrastructure.NewJWTStepUpTokenSigner(jwtSecret)
+	tokenVerifier := securityinfrastructure.NewJWTStepUpTokenVerifier(jwtSecret)
+
+	createPasswordUC := securityapplication.NewCreateTransactionPasswordUseCase(
+		passwordRepo,
+		userRepo,
+		passwordHasher,
+	)
+	authorizeStepUpUC := securityapplication.NewAuthorizeStepUpUseCase(
+		passwordRepo,
+		userRepo,
+		passwordHasher,
+		tokenRepo,
+		tokenSigner,
+		securitydomain.NewDefaultStepUpPublicOperationResolver(),
+	)
+	enforceStepUpUC := securityapplication.NewEnforceStepUpUseCase(
+		tokenVerifier,
+		tokenRepo,
+	)
+
+	transactionRepo := transactioninfrastructure.New(pool)
+	transferUC := transactionapplication.NewTransfer(transactionRepo)
+	transactionHandler := New(nil, nil, transferUC, nil, enforceStepUpUC)
+	securityHandler := securitydelivery.New(createPasswordUC, authorizeStepUpUC)
+
+	authenticatedUser := sharedauthctx.AuthenticatedUser{
+		UserID:     userID,
+		Role:       authdomain.RoleCustomer,
+		CustomerID: &sourceCustomerID,
+	}
+	withAuthenticatedUser := func(handler http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			authCtx := sharedauthctx.WithAuthenticatedUser(
+				r.Context(),
+				authenticatedUser,
+			)
+			handler(w, r.WithContext(authCtx))
+		}
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(
+		"POST /security/transaction-password",
+		withAuthenticatedUser(securityHandler.CreateTransactionPassword),
+	)
+	mux.HandleFunc(
+		"POST /security/step-up/authorize",
+		withAuthenticatedUser(securityHandler.AuthorizeStepUp),
+	)
+	mux.HandleFunc(
+		"POST /accounts/internal-transfers",
+		withAuthenticatedUser(transactionHandler.Transfer),
+	)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	createPasswordResponse := performStepUpJSONRequest(
+		t,
+		http.MethodPost,
+		server.URL+"/security/transaction-password",
+		map[string]any{
+			"transaction_password":              transactionPIN,
+			"transaction_password_confirmation": transactionPIN,
+		},
+		"",
+	)
+	assertStepUpResponseStatus(
+		t,
+		createPasswordResponse,
+		http.StatusCreated,
+		"",
+	)
+
+	firstToken := authorizeInternalTransferStepUp(
+		t,
+		server.URL,
+		transactionPIN,
+	)
+	transferPayload := map[string]any{
+		"from_account_id": sourceAccountID.String(),
+		"to_account_id":   destinationAccountID.String(),
+		"amount":          2500,
+		"idempotency_key": idempotencyKey,
+		"description":     "Aluguel de maio",
+	}
+
+	firstTransferResponse := performStepUpJSONRequest(
+		t,
+		http.MethodPost,
+		server.URL+"/accounts/internal-transfers",
+		transferPayload,
+		firstToken,
+	)
+	var firstTransfer struct {
+		Data  TransferData    `json:"data"`
+		Error *stepUpAPIError `json:"error"`
+	}
+	decodeStepUpResponse(
+		t,
+		firstTransferResponse,
+		http.StatusOK,
+		&firstTransfer,
+	)
+	if firstTransfer.Error != nil {
+		t.Fatalf("expected first transfer error to be nil, got %+v", firstTransfer.Error)
+	}
+	if firstTransfer.Data.TransactionReference == "" {
+		t.Fatal("expected first transfer to return transaction_reference")
+	}
+
+	consumedTokenResponse := performStepUpJSONRequest(
+		t,
+		http.MethodPost,
+		server.URL+"/accounts/internal-transfers",
+		transferPayload,
+		firstToken,
+	)
+	assertStepUpResponseStatus(
+		t,
+		consumedTokenResponse,
+		http.StatusUnauthorized,
+		"STEP_UP_TOKEN_CONSUMED",
+	)
+
+	secondToken := authorizeInternalTransferStepUp(
+		t,
+		server.URL,
+		transactionPIN,
+	)
+	if secondToken == firstToken {
+		t.Fatal("expected a newly authorized step-up token")
+	}
+
+	replayResponse := performStepUpJSONRequest(
+		t,
+		http.MethodPost,
+		server.URL+"/accounts/internal-transfers",
+		transferPayload,
+		secondToken,
+	)
+	var replay struct {
+		Data  TransferData    `json:"data"`
+		Error *stepUpAPIError `json:"error"`
+	}
+	decodeStepUpResponse(t, replayResponse, http.StatusOK, &replay)
+	if replay.Error != nil {
+		t.Fatalf("expected replay error to be nil, got %+v", replay.Error)
+	}
+	if replay.Data.TransactionReference != firstTransfer.Data.TransactionReference {
+		t.Fatalf(
+			"expected idempotent replay reference %q, got %q",
+			firstTransfer.Data.TransactionReference,
+			replay.Data.TransactionReference,
+		)
+	}
+
+	if balance := queryAccountBalance(t, ctx, pool, sourceAccountID); balance != 7500 {
+		t.Fatalf("expected source balance 7500 after replay, got %d", balance)
+	}
+	if balance := queryAccountBalance(t, ctx, pool, destinationAccountID); balance != 7500 {
+		t.Fatalf("expected destination balance 7500 after replay, got %d", balance)
+	}
+}
+
+type stepUpAPIError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func authorizeInternalTransferStepUp(
+	t *testing.T,
+	serverURL string,
+	transactionPIN string,
+) string {
+	t.Helper()
+
+	response := performStepUpJSONRequest(
+		t,
+		http.MethodPost,
+		serverURL+"/security/step-up/authorize",
+		map[string]any{
+			"method":               http.MethodPost,
+			"path":                 "/accounts/internal-transfers",
+			"transaction_password": transactionPIN,
+		},
+		"",
+	)
+
+	var body struct {
+		Data struct {
+			StepUpToken string `json:"step_up_token"`
+			ExpiresIn   int    `json:"expires_in"`
+		} `json:"data"`
+		Error *stepUpAPIError `json:"error"`
+	}
+	decodeStepUpResponse(t, response, http.StatusOK, &body)
+
+	if body.Error != nil {
+		t.Fatalf("expected step-up authorization error to be nil, got %+v", body.Error)
+	}
+	if body.Data.StepUpToken == "" {
+		t.Fatal("expected non-empty step_up_token")
+	}
+	if body.Data.ExpiresIn != 120 {
+		t.Fatalf("expected expires_in 120, got %d", body.Data.ExpiresIn)
+	}
+
+	return body.Data.StepUpToken
+}
+
+func performStepUpJSONRequest(
+	t *testing.T,
+	method string,
+	url string,
+	payload any,
+	stepUpToken string,
+) *http.Response {
+	t.Helper()
+
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("failed to marshal request payload: %v", err)
+	}
+
+	req, err := http.NewRequest(method, url, bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if stepUpToken != "" {
+		req.Header.Set("X-Step-Up-Token", stepUpToken)
+	}
+
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("failed to perform request: %v", err)
+	}
+
+	return response
+}
+
+func assertStepUpResponseStatus(
+	t *testing.T,
+	response *http.Response,
+	wantStatus int,
+	wantErrorCode string,
+) {
+	t.Helper()
+
+	var body struct {
+		Error *stepUpAPIError `json:"error"`
+	}
+	decodeStepUpResponse(t, response, wantStatus, &body)
+
+	if wantErrorCode == "" {
+		if body.Error != nil {
+			t.Fatalf("expected response error to be nil, got %+v", body.Error)
+		}
+		return
+	}
+
+	if body.Error == nil {
+		t.Fatalf("expected error code %q, got nil error", wantErrorCode)
+	}
+	if body.Error.Code != wantErrorCode {
+		t.Fatalf("expected error code %q, got %q", wantErrorCode, body.Error.Code)
+	}
+}
+
+func decodeStepUpResponse(
+	t *testing.T,
+	response *http.Response,
+	wantStatus int,
+	target any,
+) {
+	t.Helper()
+	defer response.Body.Close()
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+	if response.StatusCode != wantStatus {
+		t.Fatalf(
+			"expected status %d, got %d with body %s",
+			wantStatus,
+			response.StatusCode,
+			string(body),
+		)
+	}
+	if err := json.Unmarshal(body, target); err != nil {
+		t.Fatalf("failed to decode response body %s: %v", string(body), err)
+	}
+}
+
+func ensureStepUpTransferTestSchema(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+) {
+	t.Helper()
+
+	ensureDepositTestSchema(t, ctx, pool)
+
+	statements := []string{
+		`CREATE TABLE IF NOT EXISTS users (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			email VARCHAR(120) NOT NULL UNIQUE,
+			phone VARCHAR(20) UNIQUE,
+			password_hash TEXT NOT NULL,
+			role VARCHAR(20) NOT NULL,
+			customer_id UUID UNIQUE REFERENCES customers(id) ON DELETE SET NULL,
+			status VARCHAR(20) NOT NULL DEFAULT 'active',
+			email_verified_at TIMESTAMP WITH TIME ZONE,
+			phone_verified_at TIMESTAMP WITH TIME ZONE,
+			created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+			updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+		)`,
+		`ALTER TABLE users ADD COLUMN IF NOT EXISTS phone VARCHAR(20)`,
+		`ALTER TABLE users ADD COLUMN IF NOT EXISTS customer_id UUID REFERENCES customers(id) ON DELETE SET NULL`,
+		`ALTER TABLE users ADD COLUMN IF NOT EXISTS status VARCHAR(20) NOT NULL DEFAULT 'active'`,
+		`ALTER TABLE users ADD COLUMN IF NOT EXISTS email_verified_at TIMESTAMP WITH TIME ZONE`,
+		`ALTER TABLE users ADD COLUMN IF NOT EXISTS phone_verified_at TIMESTAMP WITH TIME ZONE`,
+		`CREATE TABLE IF NOT EXISTS transaction_passwords (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			password_hash TEXT NOT NULL,
+			status VARCHAR(20) NOT NULL DEFAULT 'active',
+			failed_attempts INTEGER NOT NULL DEFAULT 0,
+			locked_until TIMESTAMP WITH TIME ZONE,
+			created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+			updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+			changed_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+			CONSTRAINT chk_transaction_passwords_status
+				CHECK (status IN ('active', 'blocked')),
+			CONSTRAINT chk_transaction_passwords_failed_attempts
+				CHECK (failed_attempts >= 0),
+			CONSTRAINT chk_transaction_passwords_blocked_locked_until
+				CHECK (status <> 'blocked' OR locked_until IS NOT NULL)
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS ux_transaction_passwords_user_id
+			ON transaction_passwords(user_id)`,
+		`CREATE TABLE IF NOT EXISTS step_up_tokens (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			jti VARCHAR(120) NOT NULL,
+			user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			endpoint_key VARCHAR(120) NOT NULL,
+			status VARCHAR(20) NOT NULL DEFAULT 'active',
+			expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+			consumed_at TIMESTAMP WITH TIME ZONE,
+			created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+			CONSTRAINT chk_step_up_tokens_status
+				CHECK (status IN ('active', 'consumed')),
+			CONSTRAINT chk_step_up_tokens_jti_not_blank
+				CHECK (length(trim(jti)) > 0),
+			CONSTRAINT chk_step_up_tokens_endpoint_key_not_blank
+				CHECK (length(trim(endpoint_key)) > 0),
+			CONSTRAINT chk_step_up_tokens_expires_after_created
+				CHECK (expires_at > created_at),
+			CONSTRAINT chk_step_up_tokens_consumed_at_consistency
+				CHECK (
+					(status = 'active' AND consumed_at IS NULL)
+					OR
+					(status = 'consumed' AND consumed_at IS NOT NULL)
+				)
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS ux_step_up_tokens_jti
+			ON step_up_tokens(jti)`,
+	}
+
+	for _, statement := range statements {
+		if _, err := pool.Exec(ctx, statement); err != nil {
+			t.Fatalf("failed to ensure step-up transfer test schema: %v", err)
+		}
+	}
+}
+
+func seedStepUpTransferUser(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	userID uuid.UUID,
+	customerID uuid.UUID,
+) {
+	t.Helper()
+
+	now := time.Now().UTC()
+	email := fmt.Sprintf("step-up-transfer-%s@example.com", userID.String())
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO users (
+			id,
+			email,
+			password_hash,
+			role,
+			customer_id,
+			status,
+			created_at,
+			updated_at
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $7)
+	`, userID, email, "unused-login-password-hash", "customer", customerID, "active", now); err != nil {
+		t.Fatalf("failed to insert step-up transfer user: %v", err)
+	}
+}
+
+func cleanupStepUpTransferTestData(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	userID uuid.UUID,
+	sourceCustomerID uuid.UUID,
+	destinationCustomerID uuid.UUID,
+	sourceAccountID uuid.UUID,
+	destinationAccountID uuid.UUID,
+) {
+	t.Helper()
+
+	if _, err := pool.Exec(ctx, `DELETE FROM users WHERE id = $1`, userID); err != nil {
+		t.Logf("cleanup warning: failed to delete step-up transfer user: %v", err)
+	}
+
+	cleanupTransferTestData(
+		t,
+		ctx,
+		pool,
+		sourceCustomerID,
+		destinationCustomerID,
+		sourceAccountID,
+		destinationAccountID,
+	)
+}

--- a/api/internal/security/application/authorize_step_up.go
+++ b/api/internal/security/application/authorize_step_up.go
@@ -126,12 +126,12 @@ func (uc *AuthorizeStepUpUseCase) Execute(
 		return nil, err
 	}
 
-	if err := uc.tokenRepo.Create(ctx, stepUpToken); err != nil {
+	signedToken, err := uc.tokenSigner.Sign(stepUpToken)
+	if err != nil {
 		return nil, err
 	}
 
-	signedToken, err := uc.tokenSigner.Sign(stepUpToken)
-	if err != nil {
+	if err := uc.tokenRepo.Create(ctx, stepUpToken); err != nil {
 		return nil, err
 	}
 

--- a/api/internal/security/application/authorize_step_up_test.go
+++ b/api/internal/security/application/authorize_step_up_test.go
@@ -140,10 +140,10 @@ func TestAuthorizeStepUpUseCase_Execute_Success(t *testing.T) {
 		t.Fatalf("expected signer once, got %d", signer.signCalls)
 	}
 	if signer.token != tokenRepo.created {
-		t.Fatal("expected signer to receive the persisted step-up token instance")
+		t.Fatal("expected signer and repository to receive the same step-up token instance")
 	}
-	if got := events; len(got) != 2 || got[0] != "create-step-up-token" || got[1] != "sign-step-up-token" {
-		t.Fatalf("expected token persistence before signing, got events %v", got)
+	if got := events; len(got) != 2 || got[0] != "sign-step-up-token" || got[1] != "create-step-up-token" {
+		t.Fatalf("expected token signing before persistence, got events %v", got)
 	}
 }
 
@@ -536,7 +536,45 @@ func TestAuthorizeStepUpUseCase_Execute_ExpiredLockIsNormalizedBeforeValidation(
 	}
 }
 
-func TestAuthorizeStepUpUseCase_Execute_TokenPersistenceFailureDoesNotSign(t *testing.T) {
+func TestAuthorizeStepUpUseCase_Execute_TokenSigningFailureDoesNotPersist(t *testing.T) {
+	userID := uuid.New()
+	now := time.Date(2026, 5, 29, 10, 0, 0, 0, time.UTC)
+	expectedErr := errors.New("sign step-up token failed")
+	password := activeTransactionPassword(t, userID, "hashed-pin", now)
+	tokenRepo := &stepUpTokenRepositoryMock{}
+	signer := &stepUpTokenSignerMock{signErr: expectedErr}
+	uc := NewAuthorizeStepUpUseCase(
+		&transactionPasswordRepositoryMock{findByUserID: password},
+		&transactionPasswordUserRepositoryMock{findByIDValue: activeUser(userID)},
+		&transactionPasswordHasherMock{compareSet: true, compareMatches: true},
+		tokenRepo,
+		signer,
+		domain.NewDefaultStepUpPublicOperationResolver(),
+	)
+	uc.now = func() time.Time { return now }
+
+	output, err := uc.Execute(context.Background(), AuthorizeStepUpInput{
+		User:                authenticatedUser(userID),
+		Method:              "POST",
+		Path:                "/accounts/internal-transfers",
+		TransactionPassword: "123456",
+	})
+
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected error to wrap %v, got %v", expectedErr, err)
+	}
+	if output != nil {
+		t.Fatalf("expected nil output, got %+v", output)
+	}
+	if signer.signCalls != 1 {
+		t.Fatalf("expected signer once, got %d", signer.signCalls)
+	}
+	if tokenRepo.createCalls != 0 {
+		t.Fatalf("expected token Create not to be called, got %d", tokenRepo.createCalls)
+	}
+}
+
+func TestAuthorizeStepUpUseCase_Execute_TokenPersistenceFailureDoesNotReturnToken(t *testing.T) {
 	userID := uuid.New()
 	now := time.Date(2026, 5, 29, 10, 0, 0, 0, time.UTC)
 	expectedErr := errors.New("insert step-up token failed")
@@ -569,8 +607,8 @@ func TestAuthorizeStepUpUseCase_Execute_TokenPersistenceFailureDoesNotSign(t *te
 	if tokenRepo.createCalls != 1 {
 		t.Fatalf("expected token Create once, got %d", tokenRepo.createCalls)
 	}
-	if signer.signCalls != 0 {
-		t.Fatalf("expected signer not to be called, got %d", signer.signCalls)
+	if signer.signCalls != 1 {
+		t.Fatalf("expected signer once, got %d", signer.signCalls)
 	}
 }
 

--- a/api/internal/security/delivery/handler.go
+++ b/api/internal/security/delivery/handler.go
@@ -22,7 +22,9 @@ type authorizeStepUpUseCase interface {
 	Execute(ctx context.Context, input application.AuthorizeStepUpInput) (*application.AuthorizeStepUpOutput, error)
 }
 
+// Handler exposes the HTTP endpoints for the security module.
 type Handler struct {
+	// createTransactionPassword handles the creation of transaction passwords.
 	createTransactionPassword createTransactionPasswordUseCase
 	authorizeStepUp           authorizeStepUpUseCase
 }
@@ -49,6 +51,10 @@ type stepUpAuthorizationData struct {
 	ExpiresIn   int    `json:"expires_in"`
 }
 
+// New creates a Handler with the use cases required by security endpoints.
+//
+// The step-up authorization use case is optional to support gradual module
+// composition in scenarios where only transaction password creation is enabled.
 func New(
 	createTransactionPassword createTransactionPasswordUseCase,
 	authorizeStepUp ...authorizeStepUpUseCase,
@@ -61,6 +67,12 @@ func New(
 	return handler
 }
 
+// CreateTransactionPassword creates or updates the authenticated user's
+// transaction password.
+//
+// The handler validates authentication, decodes a strict JSON payload, and
+// delegates business rules to the corresponding use case. On success, it
+// returns HTTP 201 with transaction password metadata.
 func (h *Handler) CreateTransactionPassword(w http.ResponseWriter, r *http.Request) {
 	if h.createTransactionPassword == nil {
 		sharedhttp.WriteError(w, sharederrors.MapError(nil))
@@ -104,6 +116,12 @@ func (h *Handler) CreateTransactionPassword(w http.ResponseWriter, r *http.Reque
 	})
 }
 
+// AuthorizeStepUp authorizes a sensitive operation through step-up
+// authentication.
+//
+// The handler requires an authenticated user, validates the request body,
+// and delegates transaction password validation to the use case. On success,
+// it returns HTTP 200 with a step-up token and expiration time in seconds.
 func (h *Handler) AuthorizeStepUp(w http.ResponseWriter, r *http.Request) {
 	if h.authorizeStepUp == nil {
 		sharedhttp.WriteError(w, sharederrors.MapError(nil))
@@ -117,9 +135,7 @@ func (h *Handler) AuthorizeStepUp(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req authorizeStepUpRequest
-	decoder := json.NewDecoder(r.Body)
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&req); err != nil {
+	if err := sharedhttp.DecodeJSON(r.Body, &req); err != nil {
 		sharedhttp.WriteError(w, sharederrors.MapError(sharederrors.ErrInvalidRequest))
 		return
 	}

--- a/api/internal/security/delivery/handler_test.go
+++ b/api/internal/security/delivery/handler_test.go
@@ -160,6 +160,18 @@ func TestHandler_CreateTransactionPassword_InvalidPayload(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rec.Code)
 	}
+
+	var got struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("failed to decode response body: %v", err)
+	}
+	if got.Error.Code != "INVALID_REQUEST" {
+		t.Fatalf("expected error code %q, got %q", "INVALID_REQUEST", got.Error.Code)
+	}
 	if useCase.calls != 0 {
 		t.Fatalf("expected Execute not to be called, got %d", useCase.calls)
 	}
@@ -342,6 +354,45 @@ func TestHandler_AuthorizeStepUp_InvalidPayload(t *testing.T) {
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rec.Code)
+	}
+	if useCase.calls != 0 {
+		t.Fatalf("expected Execute not to be called, got %d", useCase.calls)
+	}
+}
+
+func TestHandler_AuthorizeStepUp_RejectsSecondJSONValue(t *testing.T) {
+	userID := uuid.New()
+	useCase := &authorizeStepUpUseCaseMock{}
+	handler := New(nil, useCase)
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/security/step-up/authorize",
+		strings.NewReader(
+			`{"method":"POST","path":"/accounts/internal-transfers","transaction_password":"123456"}{"extra":true}`,
+		),
+	)
+	req = req.WithContext(sharedauthctx.WithAuthenticatedUser(req.Context(), sharedauthctx.AuthenticatedUser{
+		UserID: userID,
+		Role:   authdomain.RoleCustomer,
+	}))
+	rec := httptest.NewRecorder()
+
+	handler.AuthorizeStepUp(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rec.Code)
+	}
+
+	var got struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("failed to decode response body: %v", err)
+	}
+	if got.Error.Code != "INVALID_REQUEST" {
+		t.Fatalf("expected error code %q, got %q", "INVALID_REQUEST", got.Error.Code)
 	}
 	if useCase.calls != 0 {
 		t.Fatalf("expected Execute not to be called, got %d", useCase.calls)

--- a/api/internal/shared/http/json.go
+++ b/api/internal/shared/http/json.go
@@ -1,0 +1,29 @@
+package sharedhttp
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// DecodeJSON decodes exactly one JSON value and rejects unknown fields.
+func DecodeJSON(body io.Reader, target any) error {
+	decoder := json.NewDecoder(body)
+	decoder.DisallowUnknownFields()
+
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("request body must contain a single JSON value")
+	}
+
+	return nil
+}

--- a/api/internal/shared/http/json_test.go
+++ b/api/internal/shared/http/json_test.go
@@ -1,0 +1,62 @@
+package sharedhttp
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDecodeJSON(t *testing.T) {
+	type request struct {
+		Name string `json:"name"`
+	}
+
+	tests := []struct {
+		name    string
+		body    string
+		wantErr bool
+	}{
+		{
+			name: "accepts one JSON object with trailing whitespace",
+			body: `{"name":"BankLab"} ` + "\n\t",
+		},
+		{
+			name:    "rejects unknown field",
+			body:    `{"name":"BankLab","extra":true}`,
+			wantErr: true,
+		},
+		{
+			name:    "rejects second JSON object",
+			body:    `{"name":"BankLab"}{"name":"Other"}`,
+			wantErr: true,
+		},
+		{
+			name:    "rejects trailing JSON primitive",
+			body:    `{"name":"BankLab"} true`,
+			wantErr: true,
+		},
+		{
+			name:    "rejects malformed JSON",
+			body:    `{"name":`,
+			wantErr: true,
+		},
+		{
+			name:    "rejects empty body",
+			body:    ``,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got request
+			err := DecodeJSON(strings.NewReader(tt.body), &got)
+
+			if tt.wantErr && err == nil {
+				t.Fatal("expected decode error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no decode error, got %v", err)
+			}
+		})
+	}
+}

--- a/api/migrations/000012_step_up_tokens_cleanup.down.sql
+++ b/api/migrations/000012_step_up_tokens_cleanup.down.sql
@@ -1,0 +1,28 @@
+DO $$
+DECLARE
+    scheduled_job record;
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_extension
+        WHERE extname = 'pg_cron'
+    ) THEN
+        FOR scheduled_job IN
+            SELECT jobid
+            FROM cron.job
+            WHERE jobname = 'cleanup-step-up-tokens'
+        LOOP
+            PERFORM cron.unschedule(scheduled_job.jobid);
+        END LOOP;
+    END IF;
+END;
+$$;
+
+DROP FUNCTION IF EXISTS cleanup_step_up_tokens();
+
+DROP INDEX IF EXISTS idx_step_up_tokens_consumed_at;
+
+DROP INDEX IF EXISTS idx_step_up_tokens_active_expires_at;
+
+CREATE INDEX IF NOT EXISTS idx_step_up_tokens_expires_at
+ON step_up_tokens (expires_at);

--- a/api/migrations/000012_step_up_tokens_cleanup.up.sql
+++ b/api/migrations/000012_step_up_tokens_cleanup.up.sql
@@ -1,0 +1,47 @@
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+DROP INDEX IF EXISTS idx_step_up_tokens_expires_at;
+
+CREATE INDEX IF NOT EXISTS idx_step_up_tokens_active_expires_at
+ON step_up_tokens (expires_at)
+WHERE status = 'active';
+
+CREATE INDEX IF NOT EXISTS idx_step_up_tokens_consumed_at
+ON step_up_tokens (consumed_at)
+WHERE status = 'consumed';
+
+CREATE OR REPLACE FUNCTION cleanup_step_up_tokens()
+RETURNS integer AS $$
+DECLARE
+    deleted_count integer;
+BEGIN
+    DELETE FROM step_up_tokens
+    WHERE (status = 'active' AND expires_at < NOW() - INTERVAL '24 hours')
+       OR (status = 'consumed' AND consumed_at < NOW() - INTERVAL '24 hours');
+
+    GET DIAGNOSTICS deleted_count = ROW_COUNT;
+    RETURN deleted_count;
+END;
+$$ LANGUAGE plpgsql;
+
+DO $$
+DECLARE
+    scheduled_job record;
+BEGIN
+    FOR scheduled_job IN
+        SELECT jobid
+        FROM cron.job
+        WHERE jobname = 'cleanup-step-up-tokens'
+    LOOP
+        PERFORM cron.unschedule(scheduled_job.jobid);
+    END LOOP;
+END;
+$$;
+
+SELECT cron.schedule(
+    'cleanup-step-up-tokens',
+    '15 3 * * *',
+    $$SELECT cleanup_step_up_tokens();$$
+);
+
+SELECT cleanup_step_up_tokens();

--- a/mobile/lib/core/resources/app_env.dart
+++ b/mobile/lib/core/resources/app_env.dart
@@ -2,15 +2,19 @@ enum AppMode { dev, staging, prod }
 
 class AppEnv {
   static const _baseUrl = String.fromEnvironment('BASE_URL');
+
   static const _appToken = String.fromEnvironment('APP_ACCESS_TOKEN');
+
   static const _connectTimeout = int.fromEnvironment(
     'CONNECT_TIMEOUT',
     defaultValue: 10000,
   );
+
   static const _receiveTimeout = int.fromEnvironment(
     'RECEIVE_TIMEOUT',
     defaultValue: 10000,
   );
+
   static const _appMode = String.fromEnvironment(
     'APP_MODE',
     defaultValue: 'dev',
@@ -51,4 +55,8 @@ class AppEnv {
   static int get receiveTimeout => _receiveTimeout;
 
   static bool get isProd => _mode == AppMode.prod;
+
+  static bool get isStaging => _mode == AppMode.staging;
+
+  static bool get isDev => _mode == AppMode.dev;
 }

--- a/mobile/lib/data/services/apis/contact_verification/contact_verification_api.dart
+++ b/mobile/lib/data/services/apis/contact_verification/contact_verification_api.dart
@@ -85,8 +85,7 @@ class ContactVerificationApi {
         );
       }
 
-      const appMode = String.fromEnvironment('APP_MODE', defaultValue: 'dev');
-      if (appMode.toLowerCase() == 'dev') {
+      if (AppEnv.isDev || AppEnv.isStaging) {
         final token =
             (resp.data as Map<String, dynamic>)['data']['debug_token']
                 as String?;

--- a/tools/bruno/banklab/collections/BankLab API/environments/BankLab Env.yml
+++ b/tools/bruno/banklab/collections/BankLab API/environments/BankLab Env.yml
@@ -9,11 +9,11 @@ variables:
   - secret: true
     name: admin_pass
   - name: base_url
-    value: http://localhost:8080
+    value: https://api.rralves.dev.br
   - secret: true
     name: app_token
   - name: id
-    value: dd7677cf-43e6-46e8-9930-96d8fe646bfc
+    value: df46c914-380e-42d2-a73b-d2fe16f82fd2
   - name: user_id
     value: ""
   - name: account_id


### PR DESCRIPTION
This update completes the transactional password step-up flow by strengthening token lifecycle management, hardening request validation, expanding integration coverage, and consolidating the public API contract around operation-based authorization.

1. `step-up token lifecycle`

   * Added migration `000012_step_up_tokens_cleanup`.
   * Introduced `cleanup_step_up_tokens()` database function.
   * Added dedicated indexes for active and consumed token cleanup paths.
   * Configured a daily `pg_cron` job to remove expired operational records.
   * Implemented a 24-hour retention window for both expired and consumed tokens.
   * Preserved short-term auditability while preventing indefinite growth of the `step_up_tokens` table.

2. `step-up authorization flow`

   * Changed token generation flow to sign the JWT before persisting the authorization record.
   * Prevented persistence of unusable step-up authorizations when token signing fails.
   * Added explicit tests covering signing failures and persistence failures.
   * Preserved the guarantee that only valid signed tokens can be stored for future enforcement.

3. `strict JSON request validation`

   * Introduced shared `DecodeJSON()` helper under `internal/shared/http`.

   * Centralized strict request decoding logic.

   * Continued rejecting unknown fields.

   * Added rejection of multiple JSON values in a single request body.

   * Prevented payloads such as:

     ```json {"field":"value"}{"extra":"payload"} ```

   * Applied the shared decoder to:

     * transaction password creation
     * step-up authorization * internal transfer requests

4. `internal transfer protection`

   * Added integration coverage for the complete protected transfer flow.
   * Validated transaction password creation.
   * Validated step-up authorization issuance.
   * Validated protected transfer execution using `X-Step-Up-Token`.
   * Verified single-use token consumption behavior.
   * Verified rejection of reused step-up tokens.
   * Verified compatibility with transfer idempotency semantics.

5. `public step-up contract`

   * Standardized authorization requests around:

     * HTTP method
     * HTTP path
   * Removed public exposure of internal endpoint policy identifiers.
   * Documented canonical uppercase method usage.
   * Added normalization rules for method handling.
   * Clarified that paths are trimmed but never rewritten or normalized by the API.
   * Reinforced the separation between public operation contracts and internal policy resolution.

6. `API documentation`

   * Documented step-up token retention and cleanup behavior.
   * Added `step_up_tokens` table to database documentation.
   * Updated implementation documentation to include operational retention rules.
   * Clarified authorization error behavior for protected transfers.
   * Documented that internal transfers return `STEP_UP_TOKEN_REQUIRED` when the authorization header is missing.
   * Expanded step-up implementation notes to reflect the final operational model.

7. `security delivery layer`

   * Added handler documentation and constructor documentation.
   * Improved endpoint self-documentation around transaction password creation and step-up authorization responsibilities.
   * Increased maintainability of the security module entry points.

8. `mobile and tooling`

   * Added `AppEnv.isDev` and `AppEnv.isStaging`.
   * Enabled contact verification debug token handling in staging environments.
   * Updated the Bruno environment to target the public staging endpoint.

This commit finalizes the operational foundations of transactional-password-based step-up authentication. Authorization tokens are now single-use, retention-managed, strictly validated at the HTTP boundary, and fully covered by end-to-end transfer integration tests, providing a safer and more predictable security model for sensitive banking operations.