### PR TITLE
2026/06/10 - refactor/centralize-auth-session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,82 @@
 # Changelog
 
+## 2026/06/10 - refactor/centralize-auth-session
+
+Refactor authentication session handling by centralizing session state in `AppSection`, removing API-driven home access decisions, and aligning mobile navigation with readiness-derived rules.
+
+### API
+
+* Removed `can_access_home` from `GET /auth/session` contract.
+* Simplified session readiness payload to expose only objective readiness state.
+* Moved responsibility for post-login navigation decisions to clients.
+* Updated session use case, handlers, DTO mappings, and tests accordingly.
+* Clarified API documentation to state that authorization remains enforced by protected endpoints independently of client navigation.
+
+### Mobile
+
+#### Session Centralization
+
+* Introduced `AppSection` as the single source of truth for the authenticated session.
+* Registered `AppSection` as an application singleton.
+* Moved cached session ownership from `AuthRepositoryImpl` to `AppSection`.
+* Updated login flow to populate `AppSection` after loading the authenticated session.
+* Updated logout flow to clear centralized session state.
+* Renamed `profile()` to `getAuthSession()` to better reflect behavior.
+* Removed repository-level `userProfile` cache access.
+
+#### Readiness Model
+
+* Removed persisted `canAccessHome` field from `ReadinessSession`.
+* Added derived readiness rules inside the domain model:
+
+  * `hasActiveTransactionPassword`
+  * `canAccessHome`
+* Added `copyWith()` support for:
+
+  * `AuthSession`
+  * `ReadinessSession`
+* Corrected naming typo:
+
+  * `CustommerSession` → `CustomerSession`
+
+#### Transaction Password Synchronization
+
+* Added local session synchronization after successful transaction password creation.
+* Implemented `AppSection.markTransactionPasswordAsActive()`.
+* Updated `TransactionPasswordRepositoryImpl` to immediately reflect active status in memory without reloading the session.
+* Updated transaction password screens and view models to rely on centralized session readiness.
+
+#### Login and Navigation
+
+* Updated login and short-login view models to resolve destinations using `AppSection`.
+* Removed dependency on repository-cached session state.
+* Changed transaction password confirmation flow to validate readiness through the centralized session before navigating home.
+* Prevented automatic navigation when transaction password creation succeeds but readiness does not allow home access.
+
+### Documentation
+
+* Documented removal of `can_access_home` from the API contract.
+* Added migration notes to completed auth-session and transaction-password backlogs.
+* Expanded internal-transfer step-up backlog with:
+
+  * session centralization strategy;
+  * transfer-entry readiness checks;
+  * transaction password reuse flow;
+  * AppSection synchronization rules;
+  * step-up retry behavior;
+  * interceptor requirements;
+  * logging and security constraints;
+  * acceptance criteria and implementation tasks.
+* Added a complete execution task breakdown for internal transfer step-up implementation.
+
+### Tests
+
+* Updated API session handler and use case tests for the new contract.
+* Added validation that `can_access_home` is no longer present in responses.
+* Updated repository, view model, and destination resolution tests to use `AppSection`.
+* Updated session fixtures and readiness builders to rely on computed readiness behavior instead of serialized API fields.
+
+
 ## 2026/06/10 - api/zta-mvp-transactional-password-16
 
 This update completes the transactional password step-up flow by strengthening token lifecycle management, hardening request validation, expanding integration coverage, and consolidating the public API contract around operation-based authorization.

--- a/api/docs/07-api-rest.md
+++ b/api/docs/07-api-rest.md
@@ -465,8 +465,7 @@ Success response (200):
       "onboarding_completed": true,
       "approved": true,
       "has_operational_account": true,
-      "transaction_password_status": "active",
-      "can_access_home": true
+      "transaction_password_status": "active"
     }
   },
   "error": null
@@ -481,7 +480,11 @@ Readiness fields:
   account.
 - `transaction_password_status`: one of `active`, `not_set`, `locked`, or
   `unknown`.
-- `can_access_home`: decision calculated by the API for post-login routing.
+
+The API returns objective readiness state and does not decide whether a client
+should display or navigate to its Home screen. Clients may derive presentation
+and navigation decisions from these fields. Authorization remains enforced by
+each protected API endpoint independently of client navigation.
 
 The response intentionally does not include `user.customer_id` or
 `customer.email`. The customer identifier is represented by `customer.id`, and

--- a/api/internal/auth/application/get_session.go
+++ b/api/internal/auth/application/get_session.go
@@ -66,7 +66,6 @@ type GetSessionReadinessOutput struct {
 	Approved                  bool
 	HasOperationalAccount     bool
 	TransactionPasswordStatus string
-	CanAccessHome             bool
 }
 
 func (uc *GetSessionUseCase) Execute(ctx context.Context) (*GetSessionOutput, error) {
@@ -116,12 +115,6 @@ func (uc *GetSessionUseCase) Execute(ctx context.Context) (*GetSessionOutput, er
 		return nil, err
 	}
 
-	onboardingCompleted := true
-	canAccessHome := onboardingCompleted &&
-		approved &&
-		hasOperationalAccount &&
-		transactionPasswordStatus == TransactionPasswordSessionStatusActive
-
 	return &GetSessionOutput{
 		User: GetSessionUserOutput{
 			ID:    user.ID,
@@ -141,7 +134,6 @@ func (uc *GetSessionUseCase) Execute(ctx context.Context) (*GetSessionOutput, er
 			Approved:                  approved,
 			HasOperationalAccount:     hasOperationalAccount,
 			TransactionPasswordStatus: transactionPasswordStatus,
-			CanAccessHome:             canAccessHome,
 		},
 	}, nil
 }

--- a/api/internal/auth/application/get_session_test.go
+++ b/api/internal/auth/application/get_session_test.go
@@ -207,9 +207,6 @@ func TestGetSessionUseCase_Execute_ActiveReadySession(t *testing.T) {
 	if output.Readiness.TransactionPasswordStatus != TransactionPasswordSessionStatusActive {
 		t.Fatalf("expected transaction password status active, got %q", output.Readiness.TransactionPasswordStatus)
 	}
-	if !output.Readiness.CanAccessHome {
-		t.Fatal("expected can_access_home true")
-	}
 }
 
 func TestGetSessionUseCase_Execute_WithoutTransactionPassword(t *testing.T) {
@@ -249,9 +246,6 @@ func TestGetSessionUseCase_Execute_WithoutTransactionPassword(t *testing.T) {
 	}
 	if output.Readiness.TransactionPasswordStatus != TransactionPasswordSessionStatusNotSet {
 		t.Fatalf("expected transaction password status not_set, got %q", output.Readiness.TransactionPasswordStatus)
-	}
-	if output.Readiness.CanAccessHome {
-		t.Fatal("expected can_access_home false")
 	}
 }
 

--- a/api/internal/auth/delivery/handler.go
+++ b/api/internal/auth/delivery/handler.go
@@ -124,7 +124,6 @@ type sessionReadinessData struct {
 	Approved                  bool   `json:"approved"`
 	HasOperationalAccount     bool   `json:"has_operational_account"`
 	TransactionPasswordStatus string `json:"transaction_password_status"`
-	CanAccessHome             bool   `json:"can_access_home"`
 }
 
 type refreshAccessTokenData struct {
@@ -414,7 +413,6 @@ func (h *Handler) Session(w http.ResponseWriter, r *http.Request) {
 			Approved:                  output.Readiness.Approved,
 			HasOperationalAccount:     output.Readiness.HasOperationalAccount,
 			TransactionPasswordStatus: output.Readiness.TransactionPasswordStatus,
-			CanAccessHome:             output.Readiness.CanAccessHome,
 		},
 	})
 }

--- a/api/internal/auth/delivery/handler_test.go
+++ b/api/internal/auth/delivery/handler_test.go
@@ -697,7 +697,6 @@ func TestHandler_Session_Success(t *testing.T) {
 				Approved:                  true,
 				HasOperationalAccount:     true,
 				TransactionPasswordStatus: "active",
-				CanAccessHome:             true,
 			},
 		},
 	}
@@ -723,12 +722,12 @@ func TestHandler_Session_Success(t *testing.T) {
 				Approved                  bool   `json:"approved"`
 				HasOperationalAccount     bool   `json:"has_operational_account"`
 				TransactionPasswordStatus string `json:"transaction_password_status"`
-				CanAccessHome             bool   `json:"can_access_home"`
 			} `json:"readiness"`
 		} `json:"data"`
 		Error any `json:"error"`
 	}
-	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+	rawBody := rec.Body.String()
+	if err := json.Unmarshal([]byte(rawBody), &got); err != nil {
 		t.Fatalf("failed to decode response body: %v", err)
 	}
 
@@ -750,8 +749,8 @@ func TestHandler_Session_Success(t *testing.T) {
 	if got.Data.Readiness.TransactionPasswordStatus != "active" {
 		t.Fatalf("expected transaction_password_status active, got %q", got.Data.Readiness.TransactionPasswordStatus)
 	}
-	if !got.Data.Readiness.CanAccessHome {
-		t.Fatal("expected can_access_home true")
+	if strings.Contains(rawBody, `"can_access_home"`) {
+		t.Fatal("expected can_access_home to be absent")
 	}
 }
 

--- a/docs/backlogs/api/done/009 - auth-session-bootstrap.md
+++ b/docs/backlogs/api/done/009 - auth-session-bootstrap.md
@@ -1,5 +1,11 @@
 # Backlog: endpoint de sessão pós-login
 
+> Decisão superveniente: `can_access_home` foi removido do contrato de
+> `GET /auth/session`. A API fornece estados objetivos de readiness, enquanto
+> cada cliente decide sua navegação. Os endpoints protegidos continuam
+> responsáveis por autenticação, autorização e regras de negócio. As menções
+> abaixo a `can_access_home` registram a decisão original deste backlog.
+
 ## 1. Contexto
 
 O mobile hoje monta o perfil do usuário após login combinando duas chamadas:

--- a/docs/backlogs/api/done/009 - auth-session-bootstrap_tasks.md
+++ b/docs/backlogs/api/done/009 - auth-session-bootstrap_tasks.md
@@ -1,5 +1,9 @@
 # Tasks do endpoint de sessão pós-login
 
+> Decisão superveniente: `can_access_home` foi removido do contrato de
+> `GET /auth/session`. As menções abaixo registram a implementação histórica;
+> o contrato vigente expõe somente os estados objetivos de readiness.
+
 Backlog pai:
 
 - `009 - auth-session-bootstrap.md`

--- a/docs/backlogs/mobile/012 - step-up-transferencia-interna.md
+++ b/docs/backlogs/mobile/012 - step-up-transferencia-interna.md
@@ -16,8 +16,17 @@ operações sensíveis:
 Este backlog trata somente do uso da senha transacional para autorizar a
 transferência interna.
 
-O cadastro da senha transacional fica em backlog independente:
-`011 - cadastro-senha-transacional.md`.
+O cadastro da senha transacional foi implementado pela backlog concluída
+`done/011 - cadastro-senha-transacional.md`.
+
+O fluxo existente de cadastro navega para a Home após sucesso. Para reutilizá-lo
+a partir da transferência, este backlog deve torná-lo consciente de uma intenção
+de retorno não sensível, sem duplicar as páginas de criação.
+
+O acesso à transferência deve verificar o estado atual da senha transacional
+quando o usuário tocar em **Transferir**. A transferência só pode ser aberta
+quando
+`AppSection.currentSession.readiness.transactionPasswordStatus` for `active`.
 
 ## 2. Objetivo
 
@@ -27,11 +36,19 @@ transacional antes da execução final.
 O fluxo mobile deve:
 
 - manter a senha transacional fora do endpoint de transferência;
+- verificar a existência de senha transacional ativa antes de abrir o fluxo de
+  transferência;
+- reutilizar o cadastro existente quando o estado for `not_set`;
 - solicitar step-up apenas no momento de confirmar a operação sensível;
 - chamar `POST /security/step-up/authorize` para obter um `step_up_token`;
 - enviar `X-Step-Up-Token` em `POST /accounts/internal-transfers`;
 - descartar o token após sucesso, erro ou cancelamento;
 - tratar erros ZTA por `error.code`;
+- preservar a `idempotency_key` durante retries da mesma tentativa lógica;
+- impedir que erros funcionais de step-up com HTTP 401 acionem indevidamente a
+  renovação da sessão;
+- impedir que senha transacional, token step-up e headers de autenticação sejam
+  registrados em logs;
 - respeitar a arquitetura mobile atual.
 
 ## 3. Contratos de API
@@ -64,9 +81,7 @@ Payload:
 
 Observação para o mobile:
 
-O mobile deve pedir autorização para a superfície pública que irá acessar. Ele
-não deve conhecer chaves internas de policy da API, como
-`internal_transfer.create`.
+O mobile deve pedir autorização para a superfície pública que irá acessar.
 
 Request:
 
@@ -99,8 +114,6 @@ Resposta de sucesso:
 
 Erros relevantes para o mobile:
 
-- `TRANSACTION_PASSWORD_NOT_SET`: usuário ainda não cadastrou senha
-  transacional;
 - `TRANSACTION_PASSWORD_INVALID`: PIN transacional incorreto;
 - `TRANSACTION_PASSWORD_LOCKED`: PIN bloqueado temporariamente por tentativas
   inválidas;
@@ -110,6 +123,11 @@ Erros relevantes para o mobile:
 - `INVALID_REQUEST`: JSON inválido ou campo inesperado;
 - `UNAUTHORIZED` / `INVALID_TOKEN`: sessão ausente ou inválida;
 - `FORBIDDEN`: usuário autenticado não está apto para a operação.
+
+`TRANSACTION_PASSWORD_NOT_SET` continua existindo no contrato defensivo da API,
+mas não é um resultado esperado deste fluxo mobile. Se ocorrer após o usuário
+ter entrado na transferência, representa inconsistência entre a verificação de
+entrada e o estado atual da credencial.
 
 ### 3.2 Executar transferência interna
 
@@ -168,33 +186,77 @@ Erros relevantes para o mobile:
 
 Ordem esperada no mobile:
 
-1. preservar ou gerar `idempotency_key` da tentativa lógica;
+1. gerar a `idempotency_key` ao criar a tentativa confirmada de transferência;
 2. solicitar senha transacional;
 3. obter `step_up_token`;
 4. executar transferência com `X-Step-Up-Token`;
 5. descartar `step_up_token` em sucesso, erro ou cancelamento.
 
+A mesma `idempotency_key` deve permanecer associada à tentativa enquanto o
+usuário estiver na confirmação e precisar repetir apenas o step-up. Uma nova
+chave deve ser gerada somente quando o usuário abandonar a tentativa ou criar
+uma nova transferência.
+
 ## 4. Fluxo de produto
+
+### 4.1 Entrada da transferência
+
+Ao tocar em **Transferir**, antes de abrir a seleção de destinatário:
+
+1. O app consulta o snapshot de sessão já carregado no login em
+   `AppSection.currentSession`.
+2. Se `transaction_password_status=active`, abre
+   `TransferRoutes.recipient`.
+3. Se `transaction_password_status=not_set`, abre o fluxo existente de criação
+   de senha transacional com intenção de retorno para a transferência.
+4. Se o status for `locked` ou `unknown`, não abre a transferência e apresenta
+   mensagem apropriada.
+5. Se o snapshot estiver ausente, mantém o usuário na Home e apresenta erro de
+   sessão, sem iniciar cadastro ou transferência.
+
+O fluxo de cadastro deve aceitar uma origem/destino tipado e não sensível:
+
+- quando iniciado pelo gate pós-login, sucesso mantém o comportamento de seguir
+  para a Home;
+- quando iniciado pelo botão **Transferir**, sucesso com resposta `active`
+  atualiza localmente o `AppSection` e abre `TransferRoutes.recipient`;
+- se o `AppSection` não confirmar status `active`, não abre a transferência;
+- `TRANSACTION_PASSWORD_ALREADY_SET` é tratado como inconsistência defensiva:
+  permanece no cadastro, sem navegar e sem atualizar localmente a sessão;
+- cancelamento do cadastro iniciado pela Home retorna à Home;
+- falha na criação mantém o usuário no cadastro e permite nova tentativa.
+
+O destino não deve ser recebido como path ou nome de rota arbitrário. Deve ser
+representado por enum ou objeto fechado, por exemplo `postLogin` e
+`internalTransfer`, e propagado entre as páginas sem incluir PIN, token ou
+draft de transferência.
+
+### 4.2 Autorização e execução
 
 Fluxo esperado:
 
-1. Usuário preenche a transferência como hoje.
+1. Após a verificação de entrada, o usuário preenche a transferência como hoje.
 2. Na confirmação, antes de executar a transferência, o app solicita a senha
    transacional.
 3. O app chama `POST /security/step-up/authorize` para autorizar
    `method=POST` e `path=/accounts/internal-transfers`.
-4. Se a autorização retornar `step_up_token`, o app chama
-   `POST /accounts/internal-transfers` com `X-Step-Up-Token`.
+4. Após a autorização retornar o `step_up_token`, o app chama obrigatoriamente
+   `POST /accounts/internal-transfers` com o header `X-Step-Up-Token`. Se a
+   autorização falhar, a transferência não deve ser chamada.
 5. O token deve ser descartado após a tentativa de transferência.
 6. Se a transferência falhar depois do enforcement, o mesmo token não deve ser
    reutilizado.
 
-Se a API retornar `TRANSACTION_PASSWORD_NOT_SET`, o app deve direcionar o
-usuário para o fluxo de cadastro de senha transacional definido na backlog
-`011 - cadastro-senha-transacional.md`.
+Se, defensivamente, a autorização retornar
+`TRANSACTION_PASSWORD_NOT_SET`, o app deve:
 
-Este backlog não precisa implementar o cadastro completo. Ele deve apenas
-reagir ao erro de senha ausente e encaminhar o usuário para o fluxo existente.
+- interromper a transferência sem chamar o endpoint protegido;
+- descartar PIN, token, draft e `idempotency_key`;
+- executar a atualização remota explícita da sessão, ignorando o snapshot atual;
+- retornar à Home;
+- permitir que um novo toque em **Transferir** encaminhe ao cadastro caso o
+  estado atualizado seja `not_set`;
+- não abrir o cadastro diretamente a partir da confirmação da transferência.
 
 ### Retry
 
@@ -204,15 +266,21 @@ reagir ao erro de senha ausente e encaminhar o usuário para o fluxo existente.
   `step_up_token`;
 - o `idempotency_key` deve continuar representando a tentativa lógica de
   transferência, não o token de step-up.
+- `STEP_UP_TOKEN_CONSUMED` e `STEP_UP_TOKEN_EXPIRED` não devem levar o usuário
+  à tela genérica de falha: o app deve permanecer ou retornar à confirmação,
+  abrir novo prompt de PIN e repetir a autorização;
+- o retry não deve reenviar automaticamente a senha transacional nem reutilizar
+  o token anterior.
 
 ## 5. Impactos na arquitetura mobile
 
 ### 5.1 Data layer
 
-Adicionar ou reutilizar API service para o módulo de segurança, seguindo o
-padrão de `mobile/lib/data/services/apis`:
+Ampliar o módulo existente de senha transacional, seguindo o padrão de
+`mobile/lib/data/services/apis/transaction_password`:
 
-- `SecurityApi` ou equivalente;
+- adicionar `authorizeStepUp` ao `TransactionPasswordApi` ou nome equivalente
+  dentro do mesmo módulo;
 - DTO de autorização step-up;
 - DTO de resposta com `step_up_token` e `expires_in`.
 
@@ -222,20 +290,54 @@ Atualizar o serviço de transferência:
 - incluir `X-Step-Up-Token` somente no `POST /accounts/internal-transfers`;
 - não enviar senha transacional no payload da transferência.
 
-### 5.2 Repository layer
+O parsing de erros deve preservar o `error.code` original da API em
+`AppError.details`, compatível com o helper existente `backendErrorCode(error)`.
+Não é requisito criar um valor de `AppErrorCode` para cada erro ZTA.
 
-Adicionar ou ampliar repositório de segurança:
+### 5.2 Cliente HTTP
+
+O cliente HTTP compartilhado deve ser ajustado para o contrato de step-up:
+
+- o `AuthInterceptor` só deve tentar refresh para respostas HTTP 401 cujo
+  `error.code` seja `UNAUTHORIZED` ou `INVALID_TOKEN`;
+- `TRANSACTION_PASSWORD_INVALID`, `STEP_UP_TOKEN_REQUIRED`,
+  `STEP_UP_TOKEN_INVALID`, `STEP_UP_TOKEN_EXPIRED` e
+  `STEP_UP_TOKEN_CONSUMED` devem chegar ao fluxo chamador sem refresh;
+- respostas 401 desconhecidas não devem ser usadas para mascarar erros
+  funcionais com uma tentativa automática de refresh;
+- logs de requests devem omitir ou mascarar `Authorization`,
+  `X-Step-Up-Token` e quaisquer valores de senha transacional;
+- nenhum log deve serializar o body de autorização step-up.
+
+### 5.3 Repository layer
+
+Ampliar o repositório existente de senha transacional:
 
 - autorizar step-up;
 - expor uma operação para autorização de transferência interna usando método e
   path públicos;
-- mapear erros ZTA para erros de aplicação.
+- preservar códigos de erro ZTA para decisão do fluxo.
 
 O repositório de transação deve continuar responsável por executar a
 transferência, mas deve receber o step-up token como parâmetro de execução ou
 por um objeto de input explícito.
 
-### 5.3 Domain/use case layer
+O snapshot autenticado deve ficar centralizado no `AppSection`:
+
+- o `AuthRepository` carrega `GET /auth/session` no login e preenche o
+  `AppSection`;
+- `getAuthSession()` pode retornar o snapshot já carregado;
+- o logout limpa o `AppSection`;
+- após criação bem-sucedida com resposta `active`, o
+  `TransactionPasswordRepository` atualiza localmente o status no
+  `AppSection`, sem nova chamada a `GET /auth/session`;
+- `TRANSACTION_PASSWORD_ALREADY_SET` não atualiza o snapshot nem libera
+  navegação;
+- uma operação remota explícita que ignore o snapshot atual deve ser usada
+  somente após `TRANSACTION_PASSWORD_NOT_SET` defensivo durante o step-up;
+- a entrada normal da transferência não chama novamente `GET /auth/session`.
+
+### 5.4 Domain/use case layer
 
 Criar ou ajustar use case para coordenar transferência protegida:
 
@@ -253,10 +355,30 @@ conheçam detalhes de múltiplos repositórios.
 O mobile deve conhecer apenas método e path públicos da API. Chaves internas de
 policy, como `internal_transfer.create`, são responsabilidade exclusiva da API.
 
-### 5.4 UI layer
+O use case também deve:
+
+- receber ou criar uma tentativa com `idempotency_key` estável antes do
+  step-up;
+- preservar essa chave ao repetir somente a autorização;
+- manter o `step_up_token` em variável local pelo tempo necessário para uma
+  única chamada de transferência;
+- descartar o token em bloco equivalente a `finally`;
+- nunca repetir automaticamente a autorização com o PIN anterior.
+
+A verificação de entrada da transferência também deve ser exposta por uma
+operação do view model ou use case, evitando que a `HomePage` consulte
+diretamente repositórios ou interprete o snapshot da sessão.
+
+### 5.5 UI layer
 
 Elementos mínimos:
 
+- verificação assíncrona ao tocar em **Transferir**, com bloqueio contra toques
+  concorrentes;
+- reaproveitamento das páginas existentes de criação e confirmação da senha
+  transacional;
+- intenção tipada para definir Home ou transferência como destino após o
+  cadastro;
 - prompt/modal/página de step-up na confirmação da transferência;
 - entrada de PIN de 6 dígitos;
 - estados de loading, sucesso e erro;
@@ -266,13 +388,26 @@ Elementos mínimos:
 O prompt de step-up deve ser transitório e não deve preservar a senha em route
 extras, cache local ou estado global.
 
+A intenção de retorno do cadastro pode trafegar entre rotas por ser não
+sensível, mas não deve aceitar paths arbitrários. O PIN atual continua
+transitório entre as duas páginas conforme o fluxo existente e deve ser limpo
+ao concluir, cancelar ou falhar uma tentativa de criação.
+
+A confirmação deve bloquear submissões concorrentes enquanto autorização ou
+transferência estiverem em andamento. Em token consumido ou expirado, ela deve
+solicitar novo PIN sem recriar a tentativa e sem navegar para a tela genérica de
+falha.
+
 ## 6. Erros que o mobile deve tratar
 
 Clientes devem depender de `error.code`.
 
+No mobile, a decisão deve usar o código preservado no `AppError`, por exemplo
+por meio de `backendErrorCode(error)`, e não comparar mensagens ou depender
+somente do status HTTP.
+
 Autorização de step-up:
 
-- `TRANSACTION_PASSWORD_NOT_SET`;
 - `TRANSACTION_PASSWORD_INVALID`;
 - `TRANSACTION_PASSWORD_LOCKED`;
 - `STEP_UP_ENDPOINT_NOT_ALLOWED`;
@@ -281,6 +416,12 @@ Autorização de step-up:
 - `UNAUTHORIZED`;
 - `INVALID_TOKEN`;
 - `FORBIDDEN`.
+
+Inconsistência defensiva:
+
+- `TRANSACTION_PASSWORD_NOT_SET`: interromper a transferência, executar a
+  atualização remota explícita da sessão e retornar à Home; o próximo acesso à
+  transferência pode iniciar o cadastro a partir da verificação de entrada.
 
 Transferência protegida:
 
@@ -300,21 +441,31 @@ Transferência protegida:
 - Permitir cancelar e voltar para a confirmação da transferência.
 - Em senha inválida, permitir nova tentativa enquanto a API permitir.
 - Em senha bloqueada, informar bloqueio temporário.
-- Em senha inexistente, direcionar para cadastro de senha transacional.
+- Em token expirado ou consumido, manter a transferência confirmada e solicitar
+  novamente a senha transacional.
+- Não exibir a tela genérica de falha antes de oferecer o novo step-up nesses
+  dois casos.
+- Em `TRANSACTION_PASSWORD_NOT_SET`, encerrar a tentativa, atualizar remotamente
+  a sessão e retornar à Home. O cadastro só pode ser aberto por uma nova
+  verificação no botão **Transferir**.
 
 ## 8. Segurança e privacidade
 
 - Não persistir senha transacional.
 - Não logar senha transacional.
 - Não logar `step_up_token` completo.
+- Não logar os headers `Authorization` e `X-Step-Up-Token`.
+- Não logar o body de `POST /security/step-up/authorize`.
 - Não armazenar `step_up_token` em secure storage.
 - Manter o token apenas em memória pelo menor tempo possível.
 - Descartar o token após sucesso, erro ou cancelamento.
 - Usar somente `error.code` para decisão de fluxo.
+- Não executar refresh de sessão para erros funcionais de step-up com HTTP 401.
 
 ## 9. Fora do escopo inicial
 
-- cadastro completo da senha transacional;
+- reimplementação completa do cadastro da senha transacional, além dos ajustes
+  de destino e sincronização do `AppSection` necessários para reutilizá-lo;
 - recuperação de senha transacional;
 - troca de senha transacional;
 - reset administrativo;
@@ -326,6 +477,20 @@ Transferência protegida:
 ## 10. Critérios de aceite
 
 - App não envia senha transacional no endpoint de transferência.
+- Botão **Transferir** consulta o snapshot já carregado no login em
+  `AppSection.currentSession`, sem nova chamada a `/auth/session`.
+- Status `active` abre a seleção de destinatário.
+- Status `not_set` abre o cadastro existente com destino tipado para
+  transferência.
+- Status `locked`, `unknown` ou falha de sessão não abre a transferência.
+- Cadastro iniciado pelo botão **Transferir** atualiza localmente o
+  `AppSection` a partir da resposta `active` e somente então abre a seleção de
+  destinatário.
+- Cadastro iniciado pelo gate pós-login mantém a Home como destino.
+- Falha de criação mantém o usuário no cadastro; cancelamento iniciado pela
+  Home retorna à Home.
+- `TRANSACTION_PASSWORD_ALREADY_SET` permanece no cadastro, sem atualizar o
+  `AppSection` e sem seguir ao destino.
 - App autoriza step-up antes de executar transferência interna.
 - Transferência interna envia `X-Step-Up-Token`.
 - Token é descartado após a tentativa.
@@ -333,16 +498,34 @@ Transferência protegida:
 - Retry com `STEP_UP_TOKEN_EXPIRED` solicita novo step-up.
 - Mesmo `idempotency_key` pode ser reutilizado com novo step-up token quando
   fizer sentido para a mesma tentativa lógica.
-- `TRANSACTION_PASSWORD_NOT_SET` direciona para o fluxo de cadastro da backlog
-  `011 - cadastro-senha-transacional.md`.
+- `TRANSACTION_PASSWORD_NOT_SET` durante step-up abandona a tentativa e retorna
+  à Home; somente um novo toque em **Transferir** pode iniciar o cadastro após
+  atualizar a sessão.
 - Erros ZTA são tratados por `error.code`.
+- `AuthInterceptor` não tenta refresh para erros funcionais de step-up com HTTP
+  401.
+- Requests não registram senha transacional, `Authorization` ou
+  `X-Step-Up-Token`.
+- `idempotency_key` é criada antes do step-up e permanece estável ao repetir a
+  autorização da mesma tentativa.
+- `STEP_UP_TOKEN_CONSUMED` e `STEP_UP_TOKEN_EXPIRED` reabrem o step-up na
+  confirmação, sem passar pela tela genérica de falha.
+- Submissões concorrentes são bloqueadas durante autorização e transferência.
 - Testes cobrem DTOs, API services, repositórios, use cases e view models
   afetados.
+- Testes cobrem os destinos pós-cadastro `postLogin` e `internalTransfer`,
+  inclusive sucesso, cancelamento, falha e o tratamento defensivo de
+  `TRANSACTION_PASSWORD_ALREADY_SET`.
+- Testes comprovam que a entrada da transferência usa o `AppSection` carregado
+  no login e que o repository atualiza seu status após criação bem-sucedida.
+- Testes do interceptor cobrem refresh para `UNAUTHORIZED`/`INVALID_TOKEN` e
+  ausência de refresh para os códigos funcionais de step-up.
+- Testes verificam sanitização de headers sensíveis em logs.
 - Documentação mobile é atualizada ao final da implementação.
 
 ## 11. Referências
 
-- `docs/backlogs/mobile/011 - cadastro-senha-transacional.md`
+- `docs/backlogs/mobile/done/011 - cadastro-senha-transacional.md`
 - `docs/backlogs/api/006b - step-up-token.md`
 - `docs/backlogs/api/006c - internal-transfer-step-up-enforcement.md`
 - `docs/backlogs/api/006d - zta-contracts-and-docs.md`

--- a/docs/backlogs/mobile/012 - step-up-transferencia-interna_tasks.md
+++ b/docs/backlogs/mobile/012 - step-up-transferencia-interna_tasks.md
@@ -1,0 +1,516 @@
+# Tasks: Step-up na transferência interna mobile
+
+Estas tasks dividem o backlog mobile de step-up na transferência interna em
+passos executáveis.
+
+O fluxo deve verificar a senha transacional ao entrar na transferência,
+reutilizar o cadastro existente quando necessário e exigir autorização step-up
+antes de executar `POST /accounts/internal-transfers`.
+
+Senha transacional, PIN e `step_up_token` devem permanecer transitórios. A
+`idempotency_key` deve permanecer estável durante retries da mesma tentativa
+lógica de transferência.
+
+## Task 1/13: Centralizar e sincronizar a sessão da aplicação
+
+### Objetivo
+
+Manter o snapshot autenticado em um serviço transversal de sessão e sincronizar
+localmente o estado da senha transacional após sua criação.
+
+### Escopo
+
+- Usar `AppSection` como fonte única do snapshot `AuthSession` durante a sessão
+  autenticada.
+- Registrar `AppSection` como singleton da aplicação.
+- Fazer o `AuthRepository` preencher o `AppSection` após carregar
+  `GET /auth/session` no login e limpá-lo no logout.
+- Manter `getAuthSession()` com retorno do snapshot em memória quando já
+  carregado.
+- Após criação bem-sucedida da senha transacional com resposta `active`, fazer
+  `TransactionPasswordRepository` atualizar localmente o
+  `transactionPasswordStatus` do `AppSection`.
+- Não chamar novamente `GET /auth/session` após a criação bem-sucedida.
+- Tratar `TRANSACTION_PASSWORD_ALREADY_SET` como inconsistência defensiva:
+  permanecer no cadastro, sem navegar e sem atualizar o snapshot
+  otimisticamente.
+- Disponibilizar atualização remota explícita que ignore o snapshot atual
+  somente para a inconsistência defensiva `TRANSACTION_PASSWORD_NOT_SET`
+  recebida durante o step-up.
+- Na atualização remota explícita, substituir o snapshot apenas após resposta
+  válida e preservar o anterior em caso de falha.
+- Não consultar novamente `GET /auth/session` na entrada normal da
+  transferência.
+
+### Critérios de aceite
+
+- Login preenche o `AppSection` com o snapshot retornado por
+  `GET /auth/session`.
+- Logout limpa o `AppSection`.
+- `getAuthSession()` pode retornar o snapshot já carregado.
+- Criação com resposta `active` atualiza o `AppSection` sem uma segunda chamada
+  de sessão.
+- `TRANSACTION_PASSWORD_ALREADY_SET` não libera Home ou transferência e não
+  altera o snapshot.
+- A atualização remota defensiva consulta `GET /auth/session`, substitui o
+  snapshot somente em sucesso e mantém a falha identificável por `AppError`.
+- A entrada normal da transferência não provoca nova consulta de sessão.
+- Testes cobrem ciclo do `AppSection`, atualização local após criação,
+  atualização remota defensiva e ausência de refresh na entrada da
+  transferência.
+
+### Depende de
+
+- Nenhuma.
+
+## Task 2/13: Tornar o cadastro de senha transacional reutilizável
+
+### Objetivo
+
+Permitir que o fluxo existente de cadastro conclua na Home ou na transferência,
+conforme sua origem.
+
+### Escopo
+
+- Criar enum ou objeto fechado para o destino pós-cadastro, com pelo menos:
+  - `postLogin`;
+  - `internalTransfer`.
+- Não aceitar path ou nome de rota arbitrário como destino.
+- Propagar o destino entre as páginas de criação e confirmação.
+- Manter o PIN transitório conforme o fluxo atual.
+- Após sucesso, usar o estado atualizado pelo
+  `TransactionPasswordRepository` antes de navegar.
+- Tratar `TRANSACTION_PASSWORD_ALREADY_SET` como falha defensiva, mantendo o
+  usuário no cadastro.
+- Para `postLogin`, navegar para a Home após confirmar que o `AppSection`
+  permite esse acesso.
+- Para `internalTransfer`, navegar para `TransferRoutes.recipient` somente se o
+  status no `AppSection` for `active`.
+- Em falha de criação, permanecer no cadastro.
+- Em cancelamento iniciado pela Home, retornar à Home.
+- Limpar PIN e confirmação ao concluir, cancelar ou falhar uma tentativa.
+
+### Critérios de aceite
+
+- O fluxo pós-login continua concluindo na Home.
+- O fluxo iniciado por **Transferir** conclui na seleção de destinatário.
+- Nenhum destino arbitrário pode ser injetado pelas rotas.
+- Sucesso com resposta `active` atualiza localmente o `AppSection`.
+- `TRANSACTION_PASSWORD_ALREADY_SET` não navega nem altera o `AppSection`.
+- Status diferente de `active` não abre a transferência.
+- Falha mantém o usuário no cadastro e permite nova tentativa sem reutilizar o
+  PIN anterior.
+- Testes cobrem os dois destinos, cancelamento, falha e senha já existente.
+
+### Depende de
+
+- Task 1.
+
+## Task 3/13: Verificar senha transacional na entrada da transferência
+
+### Objetivo
+
+Decidir o destino correto quando o usuário tocar em **Transferir**.
+
+### Escopo
+
+- Criar operação no `HomeViewmodel` ou use case dedicado para preparar a
+  entrada da transferência.
+- Consultar `AppSection.currentSession`, carregado durante o login.
+- Retornar estado tipado para:
+  - abrir transferência quando `active`;
+  - abrir cadastro quando `not_set`;
+  - bloquear quando `locked`;
+  - bloquear quando `unknown`;
+  - apresentar erro quando o snapshot estiver ausente.
+- Atualizar o botão **Transferir** para executar essa operação.
+- Bloquear toques concorrentes enquanto a verificação estiver em andamento.
+- Manter o usuário na Home em falha ou estado bloqueado.
+- Não fazer a `HomePage` interpretar diretamente o snapshot da sessão.
+
+### Critérios de aceite
+
+- `active` abre `TransferRoutes.recipient`.
+- `not_set` abre o cadastro com destino `internalTransfer`.
+- `locked` e `unknown` não abrem cadastro nem transferência.
+- Snapshot ausente mantém o usuário na Home.
+- A decisão não chama novamente `GET /auth/session`.
+- Múltiplos toques não iniciam verificações ou navegações concorrentes.
+- Testes cobrem todos os estados.
+
+### Depende de
+
+- Task 2.
+
+## Task 4/13: Restringir refresh automático aos erros de sessão
+
+### Objetivo
+
+Impedir que erros funcionais de step-up com HTTP 401 acionem renovação do access
+token.
+
+### Escopo
+
+- Fazer o `AuthInterceptor` ler `error.code` da resposta 401.
+- Tentar refresh somente para:
+  - `UNAUTHORIZED`;
+  - `INVALID_TOKEN`.
+- Não tentar refresh para:
+  - `TRANSACTION_PASSWORD_INVALID`;
+  - `STEP_UP_TOKEN_REQUIRED`;
+  - `STEP_UP_TOKEN_INVALID`;
+  - `STEP_UP_TOKEN_EXPIRED`;
+  - `STEP_UP_TOKEN_CONSUMED`.
+- Encaminhar respostas 401 funcionais ao chamador sem alterar o erro.
+- Não usar refresh automático para códigos 401 desconhecidos.
+- Preservar serialização de refresh concorrente já existente.
+
+### Critérios de aceite
+
+- `UNAUTHORIZED` e `INVALID_TOKEN` continuam tentando refresh.
+- Erros funcionais de step-up não chamam `/auth/refresh`.
+- Código e body originais chegam ao cliente chamador.
+- Refresh concorrente continua realizando uma única chamada.
+- Testes cobrem todos os códigos listados e código desconhecido.
+
+### Depende de
+
+- Nenhuma.
+
+## Task 5/13: Preservar códigos backend e sanitizar logs HTTP
+
+### Objetivo
+
+Permitir decisões por `error.code` sem expor credenciais nos logs.
+
+### Escopo
+
+- Garantir que erros retornados pelo `RestClient` preservem o código backend em
+  `AppError.details`.
+- Manter compatibilidade com `backendErrorCode(error)`.
+- Não exigir um `AppErrorCode` para cada erro ZTA.
+- Remover ou sanitizar logging genérico de headers em requests.
+- Mascarar ou omitir:
+  - `Authorization`;
+  - `X-Step-Up-Token`;
+  - outros headers reconhecidos como credenciais.
+- Não registrar body de `POST /security/step-up/authorize`.
+- Não registrar senha transacional em API services, repositories ou view
+  models.
+- Manter logs técnicos úteis sem dados sensíveis.
+
+### Critérios de aceite
+
+- `backendErrorCode(error)` identifica códigos ZTA propagados pelo cliente.
+- Logs não contêm access token, refresh token, step-up token ou PIN.
+- Logs de transferência não exibem `X-Step-Up-Token`.
+- Logs de autorização step-up não exibem o request body.
+- Testes cobrem extração de código e sanitização.
+
+### Depende de
+
+- Nenhuma.
+
+## Task 6/13: Criar DTOs e chamada de autorização step-up
+
+### Objetivo
+
+Representar e executar `POST /security/step-up/authorize`.
+
+### Escopo
+
+- Adicionar DTO de request de autorização step-up.
+- Serializar:
+  - `method`;
+  - `path`;
+  - `transaction_password`.
+- Usar representação canônica:
+  - `method=POST`;
+  - `path=/accounts/internal-transfers`.
+- Adicionar DTO de resposta com:
+  - `step_up_token`;
+  - `expires_in`.
+- Ampliar `TransactionPasswordApi` com `authorizeStepUp()` ou nome equivalente.
+- Parsear resposta com `ApiEnvelope`.
+- Preservar `error.code` nos erros.
+- Não interpretar o JWT retornado.
+- Não persistir ou logar PIN e token.
+
+### Critérios de aceite
+
+- Request gera o JSON esperado pela API.
+- API service chama `/security/step-up/authorize`.
+- Sucesso retorna token e expiração.
+- Erros de senha, sessão e policy permanecem identificáveis por código.
+- Nenhum dado sensível aparece em logs.
+- Testes cobrem serialização, sucesso, envelope inválido e falhas relevantes.
+
+### Depende de
+
+- Task 4.
+- Task 5.
+
+## Task 7/13: Ampliar o repositório de senha transacional para step-up
+
+### Objetivo
+
+Expor autorização de transferência interna sem apresentar detalhes de API à
+camada de domínio.
+
+### Escopo
+
+- Ampliar `TransactionPasswordRepository`.
+- Adicionar operação específica para autorizar transferência interna.
+- Encapsular `POST` e `/accounts/internal-transfers` no repository ou em input
+  de domínio fechado.
+- Delegar a autorização ao `TransactionPasswordApi`.
+- Retornar token e expiração somente em memória.
+- Preservar códigos backend para decisão do fluxo.
+- Não armazenar o último token no repository.
+
+### Critérios de aceite
+
+- Chamadores não precisam conhecer chaves internas como
+  `internal_transfer.create`.
+- Repository usa método e path públicos corretos.
+- Sucesso retorna token transitório.
+- Falha preserva o código backend.
+- Repository não mantém PIN nem token após a chamada.
+- Testes cobrem sucesso e erros ZTA relevantes.
+
+### Depende de
+
+- Task 6.
+
+## Task 8/13: Enviar o step-up token na transferência
+
+### Objetivo
+
+Cumprir o contrato obrigatório de `POST /accounts/internal-transfers`.
+
+### Escopo
+
+- Alterar a operação de transferência para receber o step-up token
+  explicitamente.
+- Enviar `X-Step-Up-Token` somente nessa chamada protegida.
+- Não adicionar o token como header global do cliente.
+- Não incluir o token no DTO ou body da transferência.
+- Não incluir a senha transacional no request de transferência.
+- Preservar `from_account_id`, `to_account_id`, `amount`,
+  `idempotency_key` e `description`.
+- Preservar códigos de erro do endpoint protegido.
+
+### Critérios de aceite
+
+- Transferência envia `X-Step-Up-Token`.
+- Body não contém PIN nem token.
+- Outras chamadas não recebem o header.
+- Token ausente não é substituído silenciosamente.
+- Erros `STEP_UP_TOKEN_*` permanecem identificáveis.
+- Testes verificam path, body e headers exatos.
+
+### Depende de
+
+- Task 5.
+
+## Task 9/13: Orquestrar a transferência protegida
+
+### Objetivo
+
+Coordenar autorização e execução fora da UI.
+
+### Escopo
+
+- Ajustar `TransferUsecase` ou criar operação dedicada para transferência
+  protegida.
+- Receber o draft confirmado e a senha transacional.
+- Gerar a `idempotency_key` uma vez por tentativa lógica, antes do step-up.
+- Chamar autorização step-up.
+- Chamar a transferência somente após autorização bem-sucedida.
+- Passar o token por parâmetro explícito ao repository de transação.
+- Descartar a referência ao token após uma única tentativa de transferência,
+  inclusive em erro.
+- Preservar a mesma `idempotency_key` ao repetir apenas o step-up.
+- Nunca repetir automaticamente usando o PIN anterior.
+- Nunca reutilizar o token anterior.
+
+### Critérios de aceite
+
+- Falha de autorização não chama o endpoint de transferência.
+- Sucesso de autorização chama a transferência com o token recebido.
+- Token é usado em uma única tentativa.
+- Retry de step-up mantém a mesma `idempotency_key`.
+- Nova transferência gera nova `idempotency_key`.
+- PIN não fica armazenado em repository, singleton ou estado duradouro.
+- Testes cobrem ordem das chamadas, sucesso e falhas em cada etapa.
+
+### Depende de
+
+- Task 7.
+- Task 8.
+
+## Task 10/13: Criar a experiência de entrada do PIN na confirmação
+
+### Objetivo
+
+Solicitar a senha transacional somente após o usuário confirmar os dados da
+transferência.
+
+### Escopo
+
+- Adicionar prompt, modal ou página transitória de step-up.
+- Reutilizar `TokenInput` com entrada mascarada.
+- Solicitar PIN numérico de 6 dígitos.
+- Não colocar PIN em route extra, cache, storage ou estado global.
+- Permitir cancelamento com retorno à confirmação.
+- Bloquear submissões concorrentes.
+- Exibir loading durante autorização e transferência.
+- Entregar o PIN à operação protegida e limpar o estado local imediatamente
+  depois.
+- Navegar ao sucesso somente após a transferência.
+
+### Critérios de aceite
+
+- Confirmar transferência abre a entrada de PIN antes da chamada protegida.
+- PIN incompleto não submete.
+- Cancelamento não chama autorização nem transferência.
+- Loading impede toques duplicados.
+- PIN é limpo após sucesso, falha ou cancelamento.
+- Sucesso mantém o fluxo atual de status e comprovante.
+- Testes cobrem estados principais do prompt e da confirmação.
+
+### Depende de
+
+- Task 9.
+
+## Task 11/13: Implementar decisões de erro e retry
+
+### Objetivo
+
+Tratar erros ZTA por código e preservar a tentativa correta.
+
+### Escopo
+
+- Usar `backendErrorCode(error)` para decisões de fluxo.
+- Tratar autorização:
+  - `TRANSACTION_PASSWORD_INVALID`: informar erro e permitir novo PIN;
+  - `TRANSACTION_PASSWORD_LOCKED`: informar bloqueio e impedir nova tentativa
+    imediata;
+  - `STEP_UP_ENDPOINT_NOT_ALLOWED`: encerrar com erro não recuperável;
+  - `UNAUTHORIZED` e `INVALID_TOKEN`: seguir tratamento de sessão;
+  - `FORBIDDEN`, `INVALID_DATA` e `INVALID_REQUEST`: apresentar erro adequado.
+- Tratar transferência:
+  - `STEP_UP_TOKEN_EXPIRED`: solicitar novo PIN;
+  - `STEP_UP_TOKEN_CONSUMED`: solicitar novo PIN;
+  - `STEP_UP_TOKEN_REQUIRED`, `STEP_UP_TOKEN_INVALID` e
+    `STEP_UP_ENDPOINT_MISMATCH`: não reutilizar token e apresentar falha
+    apropriada.
+- Para token expirado ou consumido, manter o draft e a `idempotency_key`.
+- Não navegar para a tela genérica de falha antes de oferecer novo step-up para
+  token expirado ou consumido.
+- Para `TRANSACTION_PASSWORD_NOT_SET`, descartar a tentativa, executar a
+  atualização remota explícita da sessão, retornar à Home e exigir nova
+  verificação no botão **Transferir**.
+- Preservar tratamento dos erros de negócio já existentes.
+
+### Critérios de aceite
+
+- Nenhuma decisão depende de mensagem textual.
+- Senha inválida permite nova entrada sem reutilizar o PIN.
+- Senha bloqueada não executa transferência.
+- Token expirado ou consumido reabre o step-up com a mesma idempotência.
+- Token anterior nunca é reutilizado.
+- `TRANSACTION_PASSWORD_NOT_SET` não abre cadastro diretamente da confirmação.
+- `TRANSACTION_PASSWORD_NOT_SET` tenta atualizar remotamente o `AppSection`
+  antes do retorno à Home.
+- Erros de negócio continuam chegando ao fluxo de status existente.
+- Testes cobrem todos os códigos ZTA listados.
+
+### Depende de
+
+- Task 9.
+- Task 10.
+
+## Task 12/13: Registrar dependências, rotas e integração do fluxo
+
+### Objetivo
+
+Conectar os novos contratos à composição atual do app.
+
+### Escopo
+
+- Registrar APIs, repositories, use cases e view models adicionados ou
+  alterados.
+- Preservar os ciclos de vida atuais quando forem compatíveis.
+- Não registrar objetos que mantenham PIN ou token como singleton/lazy
+  singleton.
+- Atualizar rotas do cadastro para transportar destino tipado.
+- Atualizar `ExtraCodec` caso o tipo de destino precise ser serializável.
+- Integrar a entrada da transferência na Home.
+- Integrar o step-up à confirmação da transferência.
+- Garantir fallback seguro para route extras ausentes ou inválidos.
+
+### Critérios de aceite
+
+- App compila com todas as dependências resolvidas.
+- Home consegue verificar sessão e abrir cadastro ou transferência.
+- Cadastro conclui no destino correto.
+- Confirmação executa autorização e transferência em sequência.
+- Extras inválidos não expõem PIN e não abrem a transferência indevidamente.
+- Nenhum singleton mantém credencial transitória.
+
+### Depende de
+
+- Task 2.
+- Task 3.
+- Task 4.
+- Task 5.
+- Task 7.
+- Task 9.
+- Task 10.
+- Task 11.
+
+## Task 13/13: Validar, testar e atualizar documentação
+
+### Objetivo
+
+Fechar a implementação com cobertura integrada, análise estática e documentação
+coerente.
+
+### Escopo
+
+- Completar testes de DTOs e API services.
+- Completar testes de repositories e use cases.
+- Completar testes de view models.
+- Cobrir atualização local do `AppSection` após criação.
+- Cobrir atualização remota da sessão após
+  `TRANSACTION_PASSWORD_NOT_SET` defensivo.
+- Cobrir uso do snapshot já carregado na entrada da transferência, sem nova
+  chamada de sessão.
+- Cobrir destinos `postLogin` e `internalTransfer`.
+- Cobrir `AuthInterceptor` para erros de sessão e step-up.
+- Cobrir sanitização de logs sensíveis.
+- Cobrir estabilidade da `idempotency_key`.
+- Cobrir descarte e não reutilização do token.
+- Adicionar widget tests para entrada da transferência, cadastro reutilizado,
+  prompt de PIN e retries críticos quando compatível com o padrão do projeto.
+- Rodar `dart format`.
+- Rodar `flutter test`.
+- Rodar `flutter analyze`.
+- Atualizar documentação mobile e changelog, se aplicável.
+
+### Critérios de aceite
+
+- Testes relevantes passam.
+- `flutter analyze` não aponta novos problemas.
+- Código está formatado.
+- Fluxo completo funciona para usuário com senha ativa.
+- Usuário sem senha é encaminhado ao cadastro e depois à transferência.
+- Falha ou cancelamento do cadastro não abre a transferência.
+- Transferência nunca é chamada sem step-up token.
+- PIN, tokens e headers de autenticação não são persistidos nem logados.
+- Backlog e documentação refletem o comportamento implementado.
+
+### Depende de
+
+- Task 12.

--- a/docs/backlogs/mobile/done/011 - cadastro-senha-transacional.md
+++ b/docs/backlogs/mobile/done/011 - cadastro-senha-transacional.md
@@ -1,5 +1,10 @@
 # Backlog: cadastro de senha transacional no mobile
 
+> Decisão superveniente: `can_access_home` foi removido de
+> `GET /auth/session`. O mobile deriva essa decisão dos estados objetivos de
+> readiness. As menções abaixo registram o contrato existente quando este
+> backlog foi implementado.
+
 ## 1. Contexto
 
 O backlog `api/006` fechou o contrato do MVP ZTA na API para criação da senha

--- a/docs/backlogs/mobile/done/011 - cadastro-senha-transacional_tasks.md
+++ b/docs/backlogs/mobile/done/011 - cadastro-senha-transacional_tasks.md
@@ -1,5 +1,9 @@
 # Tasks: Cadastro de senha transacional no mobile
 
+> Decisão superveniente: `can_access_home` foi removido de
+> `GET /auth/session`. As menções abaixo registram a implementação histórica;
+> o mobile agora deriva a navegação dos estados objetivos de readiness.
+
 Estas tasks dividem o backlog mobile de cadastro de senha transacional em
 passos executáveis.
 

--- a/mobile/lib/core/services/app_section/app_section.dart
+++ b/mobile/lib/core/services/app_section/app_section.dart
@@ -1,0 +1,34 @@
+import '/domain/common/auth/models/auth_session/auth_session.dart';
+
+class AppSection {
+  AuthSession? _current;
+
+  AuthSession? get currentSession => _current;
+
+  UserSession? get user => _current?.user;
+
+  CustomerSession? get customer => _current?.customer;
+
+  ReadinessSession? get readiness => _current?.readiness;
+
+  bool get canAccessHome =>
+      _current != null && _current!.readiness.canAccessHome;
+
+  bool get isNotNull => _current != null;
+
+  void setAuthSession(AuthSession session) => _current = session;
+
+  void clear() => _current = null;
+
+  void markTransactionPasswordAsActive() {
+    final session = _current;
+    if (session == null) return;
+
+    final readiness = session.readiness.copyWith(
+      transactionPasswordStatus: TransactionPasswordStatus.active,
+    );
+    _current = session.copyWith(
+      readiness: readiness,
+    );
+  }
+}

--- a/mobile/lib/core/services/core_services.dart
+++ b/mobile/lib/core/services/core_services.dart
@@ -6,6 +6,7 @@ import '/core/services/client_http/client/rest_client.dart';
 import '/core/services/client_http/dio/dio_factory.dart';
 import '/core/services/client_http/interceptors/interceptors.dart';
 import '../resources/app_env.dart';
+import 'app_section/app_section.dart';
 import 'client_http/dio/dio_rest_client.dart';
 import 'secure_storage/flutter_secure_storage_local_storage.dart';
 import 'secure_storage/local_secure_storage.dart';
@@ -36,6 +37,7 @@ class CoreServices {
         final dio = injector.get<Dio>();
         dio.interceptors.add(injector.get<AuthInterceptor>());
         return DioRestClient(dio: dio);
-      });
+      })
+      ..addSingleton<AppSection>(AppSection.new);
   }
 }

--- a/mobile/lib/data/repositories/auth/auth_repository.dart
+++ b/mobile/lib/data/repositories/auth/auth_repository.dart
@@ -8,10 +8,6 @@ abstract class AuthRepository {
   /// Returns the current authentication state for the app session.
   AuthUser get currentUser;
 
-  /// Returns the cached user profile for the logged-in user, if one has already
-  /// been loaded.
-  AuthSession? get userProfile;
-
   /// Indicates whether the current user is authenticated.
   bool get isLoggedIn;
 
@@ -31,7 +27,7 @@ abstract class AuthRepository {
   /// If the user is not logged in, it returns an unauthenticated failure.
   /// When available, the cached profile is returned instead of fetching it
   /// again.
-  AsyncResult<AuthSession> profile();
+  AsyncResult<AuthSession> getAuthSession();
 
   /// Retrieves the last login identity (name and identifier) from cache.
   /// Returns a failure if there is an error accessing the cache or if the

--- a/mobile/lib/data/repositories/auth/auth_repository_impl.dart
+++ b/mobile/lib/data/repositories/auth/auth_repository_impl.dart
@@ -1,5 +1,6 @@
 import '/core/resources/storage_keys.dart';
 import '/core/result/result.dart';
+import '/core/services/app_section/app_section.dart';
 import '/core/services/logging/console_log.dart';
 import '/core/services/secure_storage/local_secure_storage.dart';
 import '/data/repositories/auth/auth_repository.dart';
@@ -14,25 +15,24 @@ class AuthRepositoryImpl implements AuthRepository {
   final AuthApi _api;
   final LocalSecureStorage _storage;
   final LastLoginCacheService _lastLoginCacheService;
+  final AppSection _appSection;
 
   AuthRepositoryImpl({
     required AuthApi api,
     required LocalSecureStorage storage,
     required LastLoginCacheService lastLoginCacheService,
+    required AppSection appSection,
   }) : _api = api,
        _storage = storage,
-       _lastLoginCacheService = lastLoginCacheService;
+       _lastLoginCacheService = lastLoginCacheService,
+       _appSection = appSection;
 
   AuthUser _currentUser = NotLoggedUser();
-  AuthSession? _authSession;
 
   final _log = ConsoleLog('AuthRepositoryImpl');
 
   @override
   AuthUser get currentUser => _currentUser;
-
-  @override
-  AuthSession? get userProfile => _authSession;
 
   @override
   bool get isLoggedIn => _currentUser is LoggedUser;
@@ -50,18 +50,18 @@ class AuthRepositoryImpl implements AuthRepository {
     await _storage.write(StorageKeys.accessToken, user.accessToken);
     await _storage.write(StorageKeys.refreshToken, user.refreshToken);
 
-    final profileResult = await profile();
+    final profileResult = await getAuthSession();
     if (profileResult.isFailure) {
       // If fetching the profile fails, we should log out to clear any partial state.
       await logout();
       return Result.failure(profileResult.error!);
     }
 
-    _authSession = profileResult.value!;
+    _appSection.setAuthSession(profileResult.value!);
     final saveResult = await _lastLoginCacheService.save(
       LastLoginIdentity(
-        name: _authSession!.customer?.name ?? '***',
-        identifier: _authSession!.customer?.cpf ?? '***',
+        name: _appSection.customer?.name ?? '***',
+        identifier: _appSection.customer?.cpf ?? '***',
       ),
     );
 
@@ -86,7 +86,7 @@ class AuthRepositoryImpl implements AuthRepository {
     if (!isLoggedIn) return Success(unit);
 
     _currentUser = NotLoggedUser();
-    _authSession = null;
+    _appSection.clear();
 
     await _storage.delete(StorageKeys.accessToken);
     await _storage.delete(StorageKeys.refreshToken);
@@ -95,7 +95,7 @@ class AuthRepositoryImpl implements AuthRepository {
   }
 
   @override
-  AsyncResult<AuthSession> profile() async {
+  AsyncResult<AuthSession> getAuthSession() async {
     if (!isLoggedIn) {
       return Failure(
         AppError(
@@ -105,13 +105,13 @@ class AuthRepositoryImpl implements AuthRepository {
       );
     }
 
-    if (_authSession != null) return Success(_authSession!);
+    if (_appSection.isNotNull) return Success(_appSection.currentSession!);
 
     final result = await _api.getAuthSession();
     if (result.isFailure) return Result.failure(result.error!);
 
-    _authSession = result.value!;
+    _appSection.setAuthSession(result.value!);
 
-    return Success(_authSession!);
+    return Success(_appSection.currentSession!);
   }
 }

--- a/mobile/lib/data/repositories/transaction_password/transaction_password_repository_impl.dart
+++ b/mobile/lib/data/repositories/transaction_password/transaction_password_repository_impl.dart
@@ -1,16 +1,21 @@
 import '/core/result/result.dart';
+import '/core/services/app_section/app_section.dart';
 import '/data/services/apis/transaction_password/dtos/create_transaction_password_request_dto.dart';
 import '/data/services/apis/transaction_password/dtos/transaction_password_status_response_dto.dart';
+import '/data/services/apis/transaction_password/enums/transaction_password_status.dart';
 import '/data/services/apis/transaction_password/transaction_password_api.dart';
 import 'transaction_password_repository.dart';
 
 class TransactionPasswordRepositoryImpl
     implements TransactionPasswordRepository {
   final TransactionPasswordApi _api;
+  final AppSection _appSection;
 
   TransactionPasswordRepositoryImpl({
     required TransactionPasswordApi api,
-  }) : _api = api;
+    required AppSection appSection,
+  }) : _api = api,
+       _appSection = appSection;
 
   @override
   AsyncResult<TransactionPasswordStatusResponseDto> create(
@@ -19,6 +24,11 @@ class TransactionPasswordRepositoryImpl
     final result = await _api.create(dto);
     if (result.isFailure) return Result.failure(result.error!);
 
-    return Success(result.value!);
+    final transPasswdResp = result.value!;
+    if (transPasswdResp.status == TransactionPasswordStatus.active) {
+      _appSection.markTransactionPasswordAsActive();
+    }
+
+    return Success(transPasswdResp);
   }
 }

--- a/mobile/lib/data/services/apis/transaction_password/transaction_password_api.dart
+++ b/mobile/lib/data/services/apis/transaction_password/transaction_password_api.dart
@@ -71,7 +71,9 @@ class TransactionPasswordApi {
         );
       }
 
-      return Success(envelope.data!);
+      final transPasswdResp = envelope.data!;
+
+      return Success(transPasswdResp);
     } catch (err, stack) {
       _log.error('Error parsing response: $err', error: err, stack: stack);
       return Failure(
@@ -83,6 +85,8 @@ class TransactionPasswordApi {
     }
   }
 
+  // Additional methods for updating and deleting transaction password
+  // can be added here
   AppErrorCode _mapBackendErrorCode(String code) {
     if (code == _transactionPasswordAlreadySetBackendCode) {
       return AppErrorCode.transactionPasswordAlreadySet;

--- a/mobile/lib/domain/common/auth/models/auth_session/auth_session.dart
+++ b/mobile/lib/domain/common/auth/models/auth_session/auth_session.dart
@@ -9,7 +9,7 @@ export 'user_session.dart';
 
 class AuthSession {
   final UserSession user;
-  final CustommerSession? customer;
+  final CustomerSession? customer;
   final ReadinessSession readiness;
 
   AuthSession({
@@ -30,9 +30,21 @@ class AuthSession {
     return AuthSession(
       user: UserSession.fromApi(userMap),
       customer: customerMap != null
-          ? CustommerSession.fromApi(customerMap)
+          ? CustomerSession.fromApi(customerMap)
           : null,
       readiness: ReadinessSession.fromApi(readinessMap),
+    );
+  }
+
+  AuthSession copyWith({
+    UserSession? user,
+    CustomerSession? customer,
+    ReadinessSession? readiness,
+  }) {
+    return AuthSession(
+      user: user ?? this.user,
+      customer: customer ?? this.customer,
+      readiness: readiness ?? this.readiness,
     );
   }
 }

--- a/mobile/lib/domain/common/auth/models/auth_session/customer_session.dart
+++ b/mobile/lib/domain/common/auth/models/auth_session/customer_session.dart
@@ -1,11 +1,11 @@
-class CustommerSession {
+class CustomerSession {
   final String id;
   final String name;
   final String cpf;
   final DateTime birthDate;
   final DateTime createdAt;
 
-  CustommerSession({
+  CustomerSession({
     required this.id,
     required this.name,
     required this.cpf,
@@ -13,8 +13,8 @@ class CustommerSession {
     required this.createdAt,
   });
 
-  factory CustommerSession.fromApi(Map<String, dynamic> map) {
-    return CustommerSession(
+  factory CustomerSession.fromApi(Map<String, dynamic> map) {
+    return CustomerSession(
       id: map['id'] as String,
       name: map['name'] as String,
       cpf: map['cpf'] as String,

--- a/mobile/lib/domain/common/auth/models/auth_session/readiness_session.dart
+++ b/mobile/lib/domain/common/auth/models/auth_session/readiness_session.dart
@@ -5,14 +5,21 @@ class ReadinessSession {
   final bool approved;
   final bool hasOperationalAccount;
   final TransactionPasswordStatus transactionPasswordStatus;
-  final bool canAccessHome;
+
+  bool get hasActiveTransactionPassword =>
+      transactionPasswordStatus == TransactionPasswordStatus.active;
+
+  bool get canAccessHome =>
+      onboardingCompleted &&
+      approved &&
+      hasOperationalAccount &&
+      hasActiveTransactionPassword;
 
   ReadinessSession({
     required this.onboardingCompleted,
     required this.approved,
     required this.hasOperationalAccount,
     required this.transactionPasswordStatus,
-    required this.canAccessHome,
   });
 
   factory ReadinessSession.fromApi(Map<String, dynamic> map) {
@@ -23,7 +30,22 @@ class ReadinessSession {
       transactionPasswordStatus: TransactionPasswordStatus.byName(
         map['transaction_password_status'] as String,
       ),
-      canAccessHome: map['can_access_home'] as bool,
+    );
+  }
+
+  ReadinessSession copyWith({
+    bool? onboardingCompleted,
+    bool? approved,
+    bool? hasOperationalAccount,
+    TransactionPasswordStatus? transactionPasswordStatus,
+  }) {
+    return ReadinessSession(
+      onboardingCompleted: onboardingCompleted ?? this.onboardingCompleted,
+      approved: approved ?? this.approved,
+      hasOperationalAccount:
+          hasOperationalAccount ?? this.hasOperationalAccount,
+      transactionPasswordStatus:
+          transactionPasswordStatus ?? this.transactionPasswordStatus,
     );
   }
 }

--- a/mobile/lib/ui/pages/auth/login/viewmodel/login_viewmodel.dart
+++ b/mobile/lib/ui/pages/auth/login/viewmodel/login_viewmodel.dart
@@ -1,4 +1,5 @@
 import '/core/result/command.dart';
+import '/core/services/app_section/app_section.dart';
 import '/data/repositories/auth/auth_repository.dart';
 import '/data/services/apis/auth/dtos/login_request_dto.dart';
 import '/domain/common/auth/models/auth_user.dart';
@@ -6,16 +7,19 @@ import '../../models/post_login_destination.dart';
 
 class LoginViewModel {
   final AuthRepository _authRepository;
+  final AppSection _appSection;
 
   LoginViewModel({
     required AuthRepository authRepository,
-  }) : _authRepository = authRepository {
+    required AppSection appSection,
+  }) : _authRepository = authRepository,
+       _appSection = appSection {
     login = Command1(_authRepository.login);
   }
 
   late final Command1<LoggedUser, LoginRequestDto> login;
 
   PostLoginDestination resolvePostLoginDestination() {
-    return PostLoginDestinationResolver.resolve(_authRepository.userProfile);
+    return PostLoginDestinationResolver.resolve(_appSection.currentSession);
   }
 }

--- a/mobile/lib/ui/pages/auth/short_login/viewmodel/short_login_viewmodel.dart
+++ b/mobile/lib/ui/pages/auth/short_login/viewmodel/short_login_viewmodel.dart
@@ -1,4 +1,5 @@
 import '/core/result/command.dart';
+import '/core/services/app_section/app_section.dart';
 import '/data/repositories/auth/auth_repository.dart';
 import '/data/services/apis/auth/dtos/login_request_dto.dart';
 import '/domain/common/auth/models/auth_user.dart';
@@ -6,16 +7,19 @@ import '../../models/post_login_destination.dart';
 
 class ShortLoginViewModel {
   final AuthRepository _authRepository;
+  final AppSection _appSection;
 
   ShortLoginViewModel({
     required AuthRepository authRepository,
-  }) : _authRepository = authRepository {
+    required AppSection appSection,
+  }) : _authRepository = authRepository,
+       _appSection = appSection {
     login = Command1(_authRepository.login);
   }
 
   late final Command1<LoggedUser, LoginRequestDto> login;
 
   PostLoginDestination resolvePostLoginDestination() {
-    return PostLoginDestinationResolver.resolve(_authRepository.userProfile);
+    return PostLoginDestinationResolver.resolve(_appSection.currentSession);
   }
 }

--- a/mobile/lib/ui/pages/auth/transaction_password/confirm_transaction_password_page.dart
+++ b/mobile/lib/ui/pages/auth/transaction_password/confirm_transaction_password_page.dart
@@ -121,23 +121,35 @@ class _ConfirmTransactionPasswordPageState
       return;
     }
 
-    await _viewModel.create.execute(
-      CreateTransactionPasswordRequestDto(
-        password: widget.pin,
-        confirmation: _confirmation,
-      ),
+    final transPasswdRequest = CreateTransactionPasswordRequestDto(
+      password: widget.pin,
+      confirmation: _confirmation,
     );
+    await _viewModel.create.execute(transPasswdRequest);
 
     final result = _viewModel.create.result;
     if (result == null || !mounted) return;
 
-    if (result.isSuccess) {
-      _clearSensitiveState();
-      context.goNamed(BaseRoutes.home.name);
+    if (result.isFailure) {
+      _errorSession(result.error!);
       return;
     }
 
-    final error = result.error!;
+    if (!_viewModel.canAccessHome) {
+      AppSnackbar.show(
+        context,
+        type: SnackbarType.error,
+        message: 'Não foi possível ativar a senha transacional.',
+      );
+      return;
+    }
+
+    _clearSensitiveState();
+    context.goNamed(BaseRoutes.home.name);
+    return;
+  }
+
+  void _errorSession(AppError error) {
     if (error.code == AppErrorCode.transactionPasswordAlreadySet) {
       _clearSensitiveState();
       AppSnackbar.show(
@@ -145,7 +157,6 @@ class _ConfirmTransactionPasswordPageState
         type: SnackbarType.info,
         message: _alreadySetMessage,
       );
-      context.goNamed(BaseRoutes.home.name);
       return;
     }
 

--- a/mobile/lib/ui/pages/auth/transaction_password/viewmodel/transaction_password_viewmodel.dart
+++ b/mobile/lib/ui/pages/auth/transaction_password/viewmodel/transaction_password_viewmodel.dart
@@ -1,13 +1,20 @@
 import '/core/result/command.dart';
+import '/core/services/app_section/app_section.dart';
 import '/data/repositories/transaction_password/transaction_password_repository.dart';
 import '/data/services/apis/transaction_password/dtos/create_transaction_password_request_dto.dart';
 import '/data/services/apis/transaction_password/dtos/transaction_password_status_response_dto.dart';
+import '/domain/common/auth/models/auth_session/auth_session.dart';
 
 class TransactionPasswordViewModel {
+  final TransactionPasswordRepository _repository;
+  final AppSection _appSection;
+
   TransactionPasswordViewModel({
     required TransactionPasswordRepository repository,
-  }) {
-    create = Command1(repository.create);
+    required AppSection appSection,
+  }) : _repository = repository,
+       _appSection = appSection {
+    create = Command1(_repository.create);
   }
 
   late final Command1<
@@ -15,4 +22,8 @@ class TransactionPasswordViewModel {
     CreateTransactionPasswordRequestDto
   >
   create;
+
+  AuthSession? get currentSession => _appSection.currentSession;
+
+  bool get canAccessHome => _appSection.canAccessHome;
 }

--- a/mobile/test/data/repositories/auth/auth_repository_impl_test.dart
+++ b/mobile/test/data/repositories/auth/auth_repository_impl_test.dart
@@ -1,5 +1,6 @@
 import 'package:bankflow/core/resources/storage_keys.dart';
 import 'package:bankflow/core/result/result.dart';
+import 'package:bankflow/core/services/app_section/app_section.dart';
 import 'package:bankflow/core/services/client_http/client/rest_client.dart';
 import 'package:bankflow/core/services/client_http/client/rest_client_request.dart';
 import 'package:bankflow/core/services/client_http/client/rest_client_response.dart';
@@ -31,11 +32,13 @@ void main() {
         );
         final storage = _FakeLocalSecureStorage();
         final cache = _FakeLastLoginCacheService();
+        final appSection = AppSection();
 
         final repository = AuthRepositoryImpl(
           api: api,
           storage: storage,
           lastLoginCacheService: cache,
+          appSection: appSection,
         );
 
         final result = await repository.login(
@@ -50,7 +53,7 @@ void main() {
         expect(storage.writesByKey, isEmpty);
         expect(cache.saveCalls, 0);
         expect(repository.isLoggedIn, isFalse);
-        expect(repository.userProfile, isNull);
+        expect(appSection.currentSession, isNull);
       },
     );
 
@@ -63,11 +66,13 @@ void main() {
         );
         final storage = _FakeLocalSecureStorage();
         final cache = _FakeLastLoginCacheService();
+        final appSection = AppSection();
 
         final repository = AuthRepositoryImpl(
           api: api,
           storage: storage,
           lastLoginCacheService: cache,
+          appSection: appSection,
         );
 
         final result = await repository.login(
@@ -84,7 +89,7 @@ void main() {
         expect(cache.lastSavedIdentity?.name, 'Maria Silva');
         expect(cache.lastSavedIdentity?.identifier, '12345678901');
         expect(repository.isLoggedIn, isTrue);
-        expect(repository.userProfile?.customer?.name, 'Maria Silva');
+        expect(appSection.currentSession?.customer?.name, 'Maria Silva');
       },
     );
   });
@@ -108,7 +113,7 @@ AuthSession _profile() {
       email: 'customer@example.com',
       role: UserRole.customer,
     ),
-    customer: CustommerSession(
+    customer: CustomerSession(
       id: 'customer-1',
       name: 'Maria Silva',
       cpf: '12345678901',
@@ -120,7 +125,6 @@ AuthSession _profile() {
       approved: true,
       hasOperationalAccount: true,
       transactionPasswordStatus: TransactionPasswordStatus.active,
-      canAccessHome: true,
     ),
   );
 }

--- a/mobile/test/data/repositories/transaction_password/transaction_password_repository_impl_test.dart
+++ b/mobile/test/data/repositories/transaction_password/transaction_password_repository_impl_test.dart
@@ -1,4 +1,5 @@
 import 'package:bankflow/core/result/result.dart';
+import 'package:bankflow/core/services/app_section/app_section.dart';
 import 'package:bankflow/core/services/client_http/client_http.dart';
 import 'package:bankflow/data/repositories/transaction_password/transaction_password_repository_impl.dart';
 import 'package:bankflow/data/services/apis/transaction_password/dtos/create_transaction_password_request_dto.dart';
@@ -14,7 +15,10 @@ void main() {
       final api = _FakeTransactionPasswordApi(
         result: Success(response),
       );
-      final repository = TransactionPasswordRepositoryImpl(api: api);
+      final repository = TransactionPasswordRepositoryImpl(
+        api: api,
+        appSection: AppSection(),
+      );
       final request = _request();
 
       final result = await repository.create(request);
@@ -36,6 +40,7 @@ void main() {
             ),
           ),
         ),
+        appSection: AppSection(),
       );
 
       final result = await repository.create(_request());
@@ -58,6 +63,7 @@ void main() {
             ),
           ),
         ),
+        appSection: AppSection(),
       );
 
       final result = await repository.create(_request());
@@ -77,6 +83,7 @@ void main() {
             ),
           ),
         ),
+        appSection: AppSection(),
       );
 
       final result = await repository.create(_request());
@@ -95,6 +102,7 @@ void main() {
             ),
           ),
         ),
+        appSection: AppSection(),
       );
 
       final result = await repository.create(_request());

--- a/mobile/test/data/services/apis/auth/auth_api_get_profile_test.dart
+++ b/mobile/test/data/services/apis/auth/auth_api_get_profile_test.dart
@@ -90,7 +90,6 @@ Map<String, dynamic> _authSessionDataJson() => {
     'approved': true,
     'has_operational_account': true,
     'transaction_password_status': 'active',
-    'can_access_home': true,
   },
 };
 

--- a/mobile/test/ui/pages/auth/post_login_destination_test.dart
+++ b/mobile/test/ui/pages/auth/post_login_destination_test.dart
@@ -1,4 +1,5 @@
 import 'package:bankflow/core/result/result.dart';
+import 'package:bankflow/core/services/app_section/app_section.dart';
 import 'package:bankflow/data/repositories/auth/auth_repository.dart';
 import 'package:bankflow/data/services/apis/auth/dtos/login_request_dto.dart';
 import 'package:bankflow/data/services/cache/last_login/models/last_login_identity.dart';
@@ -15,6 +16,7 @@ void main() {
     test('returns sessionError when userProfile is missing', () {
       final viewModel = LoginViewModel(
         authRepository: _FakeAuthRepository(),
+        appSection: AppSection(),
       );
 
       expect(
@@ -24,8 +26,10 @@ void main() {
     });
 
     test('returns home for active transaction password and home readiness', () {
+      final appSection = AppSection()..setAuthSession(_session());
       final viewModel = LoginViewModel(
-        authRepository: _FakeAuthRepository(userProfile: _session()),
+        authRepository: _FakeAuthRepository(),
+        appSection: appSection,
       );
 
       expect(
@@ -35,10 +39,11 @@ void main() {
     });
 
     test('blocks active transaction password when home is not allowed', () {
+      final appSection = AppSection()
+        ..setAuthSession(_session(hasOperationalAccount: false));
       final viewModel = LoginViewModel(
-        authRepository: _FakeAuthRepository(
-          userProfile: _session(canAccessHome: false),
-        ),
+        authRepository: _FakeAuthRepository(),
+        appSection: appSection,
       );
 
       expect(
@@ -48,10 +53,11 @@ void main() {
     });
 
     test('returns transactionPassword for notSet status', () {
+      final appSection = AppSection()
+        ..setAuthSession(_session(status: TransactionPasswordStatus.notSet));
       final viewModel = LoginViewModel(
-        authRepository: _FakeAuthRepository(
-          userProfile: _session(status: TransactionPasswordStatus.notSet),
-        ),
+        authRepository: _FakeAuthRepository(),
+        appSection: appSection,
       );
 
       expect(
@@ -61,10 +67,11 @@ void main() {
     });
 
     test('blocks locked status', () {
+      final appSection = AppSection()
+        ..setAuthSession(_session(status: TransactionPasswordStatus.locked));
       final viewModel = LoginViewModel(
-        authRepository: _FakeAuthRepository(
-          userProfile: _session(status: TransactionPasswordStatus.locked),
-        ),
+        authRepository: _FakeAuthRepository(),
+        appSection: appSection,
       );
 
       expect(
@@ -74,10 +81,11 @@ void main() {
     });
 
     test('blocks unknown status', () {
+      final appSection = AppSection()
+        ..setAuthSession(_session(status: TransactionPasswordStatus.unknown));
       final viewModel = LoginViewModel(
-        authRepository: _FakeAuthRepository(
-          userProfile: _session(status: TransactionPasswordStatus.unknown),
-        ),
+        authRepository: _FakeAuthRepository(),
+        appSection: appSection,
       );
 
       expect(
@@ -89,10 +97,11 @@ void main() {
 
   group('ShortLoginViewModel.resolvePostLoginDestination', () {
     test('uses the same post-login destination rules', () {
+      final appSection = AppSection()
+        ..setAuthSession(_session(status: TransactionPasswordStatus.notSet));
       final viewModel = ShortLoginViewModel(
-        authRepository: _FakeAuthRepository(
-          userProfile: _session(status: TransactionPasswordStatus.notSet),
-        ),
+        authRepository: _FakeAuthRepository(),
+        appSection: appSection,
       );
 
       expect(
@@ -105,7 +114,7 @@ void main() {
 
 AuthSession _session({
   TransactionPasswordStatus status = TransactionPasswordStatus.active,
-  bool canAccessHome = true,
+  bool hasOperationalAccount = true,
 }) {
   return AuthSession(
     user: UserSession(
@@ -113,7 +122,7 @@ AuthSession _session({
       email: 'customer@example.com',
       role: UserRole.customer,
     ),
-    customer: CustommerSession(
+    customer: CustomerSession(
       id: 'customer-1',
       name: 'Maria Silva',
       cpf: '12345678901',
@@ -123,20 +132,17 @@ AuthSession _session({
     readiness: ReadinessSession(
       onboardingCompleted: true,
       approved: true,
-      hasOperationalAccount: true,
+      hasOperationalAccount: hasOperationalAccount,
       transactionPasswordStatus: status,
-      canAccessHome: canAccessHome,
     ),
   );
 }
 
 class _FakeAuthRepository implements AuthRepository {
-  _FakeAuthRepository({
-    this.userProfile,
-  });
+  _FakeAuthRepository();
 
   @override
-  final AuthSession? userProfile;
+  AuthSession? get userProfile => null;
 
   @override
   AuthUser get currentUser => NotLoggedUser();
@@ -156,5 +162,5 @@ class _FakeAuthRepository implements AuthRepository {
   AsyncResult<Unit> logout() async => throw UnimplementedError();
 
   @override
-  AsyncResult<AuthSession> profile() async => throw UnimplementedError();
+  AsyncResult<AuthSession> getAuthSession() async => throw UnimplementedError();
 }

--- a/mobile/test/ui/pages/auth/transaction_password/viewmodel/transaction_password_viewmodel_test.dart
+++ b/mobile/test/ui/pages/auth/transaction_password/viewmodel/transaction_password_viewmodel_test.dart
@@ -1,4 +1,5 @@
 import 'package:bankflow/core/result/result.dart';
+import 'package:bankflow/core/services/app_section/app_section.dart';
 import 'package:bankflow/data/repositories/transaction_password/transaction_password_repository.dart';
 import 'package:bankflow/data/services/apis/transaction_password/dtos/create_transaction_password_request_dto.dart';
 import 'package:bankflow/data/services/apis/transaction_password/dtos/transaction_password_status_response_dto.dart';
@@ -17,7 +18,10 @@ void main() {
       final repository = _FakeTransactionPasswordRepository(
         result: Success(response),
       );
-      final viewModel = TransactionPasswordViewModel(repository: repository);
+      final viewModel = TransactionPasswordViewModel(
+        repository: repository,
+        appSection: AppSection(),
+      );
       final request = CreateTransactionPasswordRequestDto(
         password: '123456',
         confirmation: '123456',
@@ -41,7 +45,10 @@ void main() {
           ),
         ),
       );
-      final viewModel = TransactionPasswordViewModel(repository: repository);
+      final viewModel = TransactionPasswordViewModel(
+        repository: repository,
+        appSection: AppSection(),
+      );
 
       await viewModel.create.execute(
         CreateTransactionPasswordRequestDto(


### PR DESCRIPTION
Refactor authentication session handling by centralizing session state in `AppSection`, removing API-driven home access decisions, and aligning mobile navigation with readiness-derived rules.

### API

* Removed `can_access_home` from `GET /auth/session` contract.
* Simplified session readiness payload to expose only objective readiness state.
* Moved responsibility for post-login navigation decisions to clients.
* Updated session use case, handlers, DTO mappings, and tests accordingly.
* Clarified API documentation to state that authorization remains enforced by protected endpoints independently of client navigation.

### Mobile

#### Session Centralization

* Introduced `AppSection` as the single source of truth for the authenticated session.
* Registered `AppSection` as an application singleton.
* Moved cached session ownership from `AuthRepositoryImpl` to `AppSection`.
* Updated login flow to populate `AppSection` after loading the authenticated session.
* Updated logout flow to clear centralized session state.
* Renamed `profile()` to `getAuthSession()` to better reflect behavior.
* Removed repository-level `userProfile` cache access.

#### Readiness Model

* Removed persisted `canAccessHome` field from `ReadinessSession`.
* Added derived readiness rules inside the domain model:

  * `hasActiveTransactionPassword`
  * `canAccessHome`
* Added `copyWith()` support for:

  * `AuthSession`
  * `ReadinessSession`
* Corrected naming typo:

  * `CustommerSession` → `CustomerSession`

#### Transaction Password Synchronization

* Added local session synchronization after successful transaction password creation.
* Implemented `AppSection.markTransactionPasswordAsActive()`.
* Updated `TransactionPasswordRepositoryImpl` to immediately reflect active status in memory without reloading the session.
* Updated transaction password screens and view models to rely on centralized session readiness.

#### Login and Navigation

* Updated login and short-login view models to resolve destinations using `AppSection`.
* Removed dependency on repository-cached session state.
* Changed transaction password confirmation flow to validate readiness through the centralized session before navigating home.
* Prevented automatic navigation when transaction password creation succeeds but readiness does not allow home access.

### Documentation

* Documented removal of `can_access_home` from the API contract.
* Added migration notes to completed auth-session and transaction-password backlogs.
* Expanded internal-transfer step-up backlog with:

  * session centralization strategy;
  * transfer-entry readiness checks;
  * transaction password reuse flow;
  * AppSection synchronization rules;
  * step-up retry behavior;
  * interceptor requirements;
  * logging and security constraints;
  * acceptance criteria and implementation tasks.
* Added a complete execution task breakdown for internal transfer step-up implementation.

### Tests

* Updated API session handler and use case tests for the new contract.
* Added validation that `can_access_home` is no longer present in responses.
* Updated repository, view model, and destination resolution tests to use `AppSection`.
* Updated session fixtures and readiness builders to rely on computed readiness behavior instead of serialized API fields.